### PR TITLE
Close stale issues and pull requests

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,23 @@
+# TODO: Add Probot to this repository for this configuration to take effect.
+# It only requires write access to pull requests and issues.
+# https://probot.github.io/apps/stale/
+
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 60
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 14
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - pinned
+  - security
+# Label to use when marking an issue as stale
+staleLabel: stale
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: >
+  This issue has been automatically closed because it has had no further
+  activity since being marked as stale.


### PR DESCRIPTION
* Probot https://probot.github.io/apps/stale/ will need to be installed through the dxw organisation for this to work automatically. Otherwise a human will need to go into the github integration settings and add new projects one by one, if that's not agreeable then this probably isn't useful to us
* Removing noise and stale issues and pull requests automatically should keep us honest and proactive about dealing with things that are important before they disappear, if they aren't important then if it disappears then less noise is a positive