### PR TITLE
Add a basic check endpoint

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base
+  def health_check
+    render json: {rails: "OK"}, status: :ok
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
+  get "health_check" => "application#health_check"
   root to: "visitors#index"
 end

--- a/spec/requests/health_check_spec.rb
+++ b/spec/requests/health_check_spec.rb
@@ -1,0 +1,9 @@
+require "rails_helper"
+
+RSpec.describe "Health Check", type: :request do
+  it "returns an ok HTTP status code without requiring authentication" do
+    get "/health_check", headers: {"CONTENT_TYPE" => "application/json", "ACCEPT" => "application/json"}
+    expect(response).to have_http_status(:ok)
+    expect(JSON.parse(response.body)).to eql("rails" => "OK")
+  end
+end


### PR DESCRIPTION
## Changes in this PR

* For monitoring purposes we need a basic and light weight way to check th answer to the simple question: is the web server  running and responding to requests?
* For purposes of deployments we very often have to provide health check paths so that the infrastructure can check them to delcare new versions of the application as healthy. If the application is not healthy, the deployment will rollback and abort.
* This could be implemented by changing the routes file `get '/check', to: proc { [200, {}, ['OK']] }` however I think placing this in the application controller is more conventional location (I might be wrong on this). The team will be able to see it within the context of before filters and authentication logic.
* Only a basic JSON message is returned to fulfil this purpose. Given that health checks are run more than once a minute on services, these requests can soon mount up and impact performance.
