### PR TITLE
Run specs in random order by default

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -82,11 +82,11 @@ RSpec.configure do |config|
   #   # particularly slow.
   #   config.profile_examples = 10
   #
-  #   # Run specs in random order to surface order dependencies. If you find an
-  #   # order dependency and want to debug it, you can fix the order by providing
-  #   # the seed, which is printed after each run.
-  #   #     --seed 1234
-  #   config.order = :random
+  # Run specs in random order to surface order dependencies. If you find an
+  # order dependency and want to debug it, you can fix the order by providing
+  # the seed, which is printed after each run.
+  #     --seed 1234
+  config.order = :random
   #
   #   # Seed global randomization in this process using the `--seed` CLI option.
   #   # Setting this allows you to use `--seed` to deterministically reproduce


### PR DESCRIPTION
This sets the Rspec config to run the specs in random order, this helps ensure our tests are decoupled from each other