### PR TITLE
Set css_compressor=nil to enable assets to precompile with Rails 6/Sprockets 4

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -26,7 +26,8 @@ Rails.application.configure do
 
   # Compress JavaScripts and CSS.
   config.assets.js_compressor = :uglifier
-  # config.assets.css_compressor = :sass
+  # Set a css_compressor so sassc-rails does not overwrite the compressor when running the tests
+  config.assets.css_compressor = nil
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -46,6 +46,9 @@ Rails.application.configure do
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 
+  # Set a css_compressor so sassc-rails does not overwrite the compressor when running the tests
+  config.assets.css_compressor = nil
+
   config.after_initialize do
     Bullet.enable = true
     Bullet.bullet_logger = true


### PR DESCRIPTION
## Changes in this PR

While working on beis-report-overseas-development-assistance we encountered an
issue where the assets would not precompile in `production` when using govuk-frontend

After a lot of digging we found the following issue:

https://github.com/sass/sassc-rails/issues/93

Which was used by @mec in dfe-teachers-payment-service:

https://github.com/DFE-Digital/dfe-teachers-payment-service/commit/74ec587cfbe9aa6d0df01a72e99d70ffe9024748

To save everyone else the pain we suggest this is added to rails-template!

BEIS reference: https://github.com/UKGovernmentBEIS/beis-report-overseas-development-assistance/pull/4/commits/2e9f351b57153a5947565f913f8ac97ff264bec6


