### PR TITLE
Do not try to load Dotenv in production

### DIFF
--- a/config/initializers/dotenv.rb
+++ b/config/initializers/dotenv.rb
@@ -1,3 +1,3 @@
 # Require environment variables on initialisation
 # https://github.com/bkeepers/dotenv#required-keys
-Dotenv.require_keys
+Dotenv.require_keys if defined?(Dotenv)


### PR DESCRIPTION
## Changes in this PR

Dotenv is not used in production, so do not try to load it if it is not defined.

This was causing issues in the `beis-report-overseas-development-assistance`
project, which was spun off from this template.

https://github.com/UKGovernmentBEIS/beis-report-overseas-development-assistance/pull/4/commits/08b9fd44a7a8100a6b462f1fc0f46a415e1805f6