### PR TITLE
form_with generates local forms by default

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -24,6 +24,10 @@ module RailsTemplate
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2
 
+    # Make sure the `form_with` helper generates local forms, instead of defaulting
+    # to remote and unobtrusive XHR forms
+    config.action_view.form_with_generates_remote_forms = false
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading


### PR DESCRIPTION
[`form_with`](https://apidock.com/rails/ActionView/Helpers/FormHelper/form_with) is a super-useful helper for generating forms, however, by default it assumes that forms are submitted by remote and unobtrusive XHRs (sending `format: :js` to the controller). For most of our use cases, this won't be the case, so we can set an application-wide default and use `form_with` without having to remember to set `remote: false` every time.