### PR TITLE
Link to dxw RFCs and reference notable decisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # Using this template
 
-Search for `TODO` across the project to customise the template to a project
+1. Search for `TODO` across the repository to customise the template to the new
+  project
+1. Be aware of [dxw RFCs](https://github.com/dxw/tech-team-rfcs), especially
+  those that have not resulted in a default code change in this repository:
+  - [rfc-013-use-docker-to-deploy-and-run-applications-in-containers](https://github.com/dxw/tech-team-rfcs/blob/master/rfc-013-use-docker-to-deploy-and-run-applications-in-containers.md)
 
 TODO: Remove this section from the README once complete
 


### PR DESCRIPTION
## Changes in this PR

* In a recent discussion on tech-team-rfcs we wanted to make sure that decisions we made that were not common enough to warrant a code change, were still easily discoverable. https://github.com/dxw/tech-team-rfcs/pull/21#pullrequestreview-305305992. Whilst that PR has driven it, as it is not yet merged it cannot and shouldn't be linked to yet. Fortunately there was another good candidate for this in the decision to use containers in live.
