### PR TITLE
Add support for building docker containers

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,3 +1,5 @@
+# TODO: Enable GitHub Actions on the repository to test all pull requests
+# https://github.com/<org>/<repo>/actions
 name: CI
 
 on: pull_request
@@ -7,34 +9,20 @@ jobs:
     runs-on: ubuntu-latest
     env:
       RAILS_ENV: test
-    services:
-      postgres:
-        image: postgres:10.8
-        env:
-          POSTGRES_USER: test
-          POSTGRES_DB: postgres
-        ports:
-        - 5432:5432
-        # needed because the postgres container does not provide a healthcheck
-        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
     steps:
-      - uses: actions/checkout@v1
-      - name: Set Ruby version to use
-        run: |
-          echo "::set-env name=RUBY_VERSION::$(cat .ruby-version)"
-      - uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: ${{ env.RUBY_VERSION }}
-      - name: Install dependencies
-        run: |
-          sudo apt-get install libpq-dev
-          gem install bundler
-          bundle install --jobs 4 --retry 3
-      - name: Set up the test database
-        run: |
-          RAILS_ENV=test bundle exec rake db:setup
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Set up Docker
+        run: docker network create test
+      - name: Set up Postgres
+        run: docker run -d --name pg --network test -e POSTGRES_USER=test -e POSTGRES_HOST_AUTH_METHOD=trust -p 5432:5432 postgres:11
+      - name: Build a new Docker image
+        run: docker build . --build-arg RAILS_ENV=test -t app:test
       - name: Run the tests
         run: |
-          bundle exec rake
-      - name: Brakeman action
-        uses: artplan1/brakeman-action@v1.2.1
+          docker run --name test-container \
+            --network test \
+            -e RAILS_ENV=test \
+            -e DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL=true \
+            -e DATABASE_URL=postgres://test@pg:5432/app_test \
+            app:test bundle exec rake

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,41 @@
+FROM ruby:2.6.3 as release
+MAINTAINER dxw <rails@dxw.com>
+RUN apt-get update && apt-get install -qq -y \
+  build-essential \
+  libpq-dev \
+  --fix-missing --no-install-recommends
+RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - \
+        && apt-get install -y nodejs
+
+ENV INSTALL_PATH /srv/app
+RUN mkdir -p $INSTALL_PATH
+
+WORKDIR $INSTALL_PATH
+
+# set rails environment
+ARG RAILS_ENV
+ENV RAILS_ENV=${RAILS_ENV:-production}
+ENV RACK_ENV=${RAILS_ENV:-production}
+
+COPY Gemfile $INSTALL_PATH/Gemfile
+COPY Gemfile.lock $INSTALL_PATH/Gemfile.lock
+
+RUN gem update --system
+RUN gem install bundler
+
+# bundle ruby gems based on the current environment, default to production
+RUN echo $RAILS_ENV
+RUN \
+  if [ "$RAILS_ENV" = "production" ]; then \
+    bundle install --without development test --retry 10; \
+  else \
+    bundle install --retry 10; \
+  fi
+
+COPY . $INSTALL_PATH
+
+RUN RAILS_ENV=$RAILS_ENV SECRET_KEY_BASE="super secret" bundle exec rake assets:precompile --quiet
+
+EXPOSE 3000
+
+CMD ["rails", "server"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,11 @@ COPY . $INSTALL_PATH
 
 RUN RAILS_ENV=$RAILS_ENV SECRET_KEY_BASE="super secret" bundle exec rake assets:precompile --quiet
 
+# db setup
+COPY ./docker-entrypoint.sh /
+RUN chmod +x /docker-entrypoint.sh
+ENTRYPOINT ["/docker-entrypoint.sh"]
+
 EXPOSE 3000
 
 CMD ["rails", "server"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -e
+
+echo "ENTRYPOINT: Starting docker entrypoint…"
+
+setup_database()
+{
+  echo "ENTRYPOINT: Checking database setup is up-to-date…"
+  # Rails will throw an error if no database exists"
+  #   PG::ConnectionBad: FATAL:  database "roda-development" does not exist
+  if rake db:migrate:status &> /dev/null; then
+    echo "ENTRYPOINT: Database found, running db:migrate…"
+    rake db:migrate
+  else
+    if [ "$RAILS_ENV" == "production" ]; then
+      echo "ENTRYPOINT: Environment is production, doing nothing."
+    else
+      echo "ENTRYPOINT: Environment is in non-production, attempting to automatically create the database…"
+      echo "ENTRYPOINT: Running db:create db:schema:load…"
+      rake db:create db:environment:set db:schema:load
+    fi
+  fi
+  echo "ENTRYPOINT: Finished database setup"
+}
+
+if [ -z ${DATABASE_URL+x} ]; then echo "Skipping database setup"; else setup_database; fi
+
+echo "ENTRYPOINT: Finished docker entrypoint."
+exec "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -5,22 +5,10 @@ echo "ENTRYPOINT: Starting docker entrypoint…"
 
 setup_database()
 {
-  echo "ENTRYPOINT: Checking database setup is up-to-date…"
-  # Rails will throw an error if no database exists"
-  #   PG::ConnectionBad: FATAL:  database "roda-development" does not exist
-  if rake db:migrate:status &> /dev/null; then
-    echo "ENTRYPOINT: Database found, running db:migrate…"
-    rake db:migrate
-  else
-    if [ "$RAILS_ENV" == "production" ]; then
-      echo "ENTRYPOINT: Environment is production, doing nothing."
-    else
-      echo "ENTRYPOINT: Environment is in non-production, attempting to automatically create the database…"
-      echo "ENTRYPOINT: Running db:create db:schema:load…"
-      rake db:create db:environment:set db:schema:load
-    fi
-  fi
-  echo "ENTRYPOINT: Finished database setup"
+  echo "ENTRYPOINT: Running rake db:prepare…"
+  # Migrate the database and if one doesn't exist then create one
+  bundle exec rake db:prepare
+  echo "ENTRYPOINT: Finished database setup."
 }
 
 if [ -z ${DATABASE_URL+x} ]; then echo "Skipping database setup"; else setup_database; fi


### PR DESCRIPTION
## Changes in this PR

From [the decision to use containers in live environments](https://github.com/UKGovernmentBEIS/beis-report-overseas-development-assistance) we know that all Rails applications will need the ability to create a working docker container. To assist with this we can contribute a default Dockerfile that will create a docker image.

Most of this proposal is from [the fresh(ish) RODA application](https://github.com/UKGovernmentBEIS/beis-report-overseas-development-assistance) that used the template and has already had to look to past examples to find a stable and working foundation.

Now that the project has a Dockerfile, the GitHub Action used to test our pull requests has been switched over. This is also part of the above decision to use Docker in live **and** CI.

We could use this opportunity to add the GOV.UK Design system as a multi stage build, but I feel that change should be done at the same time we remove Bootstrap.
