### PR TITLE
Speed up tests, without causing Spring errors

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -8,7 +8,11 @@
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
-  config.cache_classes = false
+  config.cache_classes = true
+
+  # Prevent 'reloading is disabled' errors from Spring
+  # https://github.com/rails/spring/issues/598
+  config.autoloader = :classic
 
   # Do not eager load code on boot. This avoids loading your whole application
   # just for the purpose of running a single test. If you are using a tool that


### PR DESCRIPTION
It appears that Spring currently has some problems interacting with Zeitwerk, the new autoloader that was added in Rails 6.

The recommended workaround has caused `rails new` to set `config.cache_classes = false` by default, which causes a test suite to run very slowly, especially when Capybara is being used.

An alternative workaround was mentioned in the Spring repo (https://github.com/rails/spring/issues/598), which allows `cache_classes = true` to be set. The compromise is that it uses the 'classic' autoloader instead of Zeitwerk.

This was discovered whilst working on the BEIS RODA project (https://github.com/UKGovernmentBEIS/beis-report-official-development-assistance/pull/44)