### PR TITLE
Fix Github actions

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -5,6 +5,18 @@ on: pull_request
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      RAILS_ENV: test
+    services:
+      postgres:
+        image: postgres:10.8
+        env:
+          POSTGRES_USER: test
+          POSTGRES_DB: postgres
+        ports:
+        - 5432:5432
+        # needed because the postgres container does not provide a healthcheck
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
     steps:
       - uses: actions/checkout@v1
       - name: Set Ruby version to use
@@ -13,9 +25,6 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ env.RUBY_VERSION }}
-      - name: Set up Postgres
-        run: |
-          docker run -d --name postgres -e POSTGRES_USER=test -p 5432:5432 postgres:11
       - name: Install dependencies
         run: |
           sudo apt-get install libpq-dev

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -7,9 +7,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: actions/setup-ruby@v1
+      - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "2.6.3"
+          ruby-version: 2.6.3
       - name: Set up Postgres
         run: |
           docker run -d --name postgres -e POSTGRES_USER=test -p 5432:5432 postgres:11

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -7,9 +7,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
+      - name: Set Ruby version to use
+        run: |
+          echo "::set-env name=RUBY_VERSION::$(cat .ruby-version)"
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.6.3
+          ruby-version: ${{ env.RUBY_VERSION }}
       - name: Set up Postgres
         run: |
           docker run -d --name postgres -e POSTGRES_USER=test -p 5432:5432 postgres:11


### PR DESCRIPTION
As outlined in the documentation (https://github.com/actions/setup-ruby), `actions/setup-ruby` does not support patch versions, so the actions build is currently failing. 

This fixes the action to use `ruby/setup-ruby`, which supports a wider range of Ruby versions, and also uses whatever version is specified in `.ruby-version` to avoid repetition. 

I've also fixed the Postgres step, which didn't seem to be working either.