### PR TITLE
Test database can be created with the default postgres user

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -6,4 +6,4 @@
 # Reference: https://github.com/bkeepers/dotenv#what-other-env-files-can-i-use
 
 # TODO: Replace `rails-template` with the name of the app.
-DATABASE_URL=postgres://test@localhost:5432/rails-template-test
+DATABASE_URL=postgres://postgres@localhost:5432/rails-template-test


### PR DESCRIPTION
## Changes in this PR

Before this change the user (me) was required to create a new role in the local postgres database using the equivalant to: `createuser --super test`.

We could avoid this hurdle by using the default postgres role that's named `postgres`. This is what's used in the development configuration (see .env.example). The separate database names for `rails-template-development` and `rails-template-test` should continue to provide enough separation.