### PR TITLE
Remove Selenium deprecation warning

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,6 @@ end
 
 group :test do
   gem "capybara", ">= 2.15"
-  gem "chromedriver-helper"
   gem "selenium-webdriver"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,7 +60,7 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     archive-zip (0.12.0)
       io-like (~> 0.3.0)
-    ast (2.4.1)
+    ast (2.4.0)
     autoprefixer-rails (9.8.6.1)
       execjs
     better_errors (2.7.1)
@@ -89,9 +89,6 @@ GEM
       regexp_parser (~> 1.5)
       xpath (~> 3.2)
     childprocess (3.0.0)
-    chromedriver-helper (2.1.1)
-      archive-zip (~> 0.10)
-      nokogiri (~> 1.8)
     coderay (1.1.3)
     coffee-rails (5.0.0)
       coffee-script (>= 2.2.0)
@@ -139,8 +136,9 @@ GEM
     i18n (1.7.1)
       concurrent-ruby (~> 1.0)
     io-like (0.3.0)
-    jbuilder (2.10.0)
-      activesupport (>= 5.0.0)
+    jaro_winkler (1.5.4)
+    jbuilder (2.9.1)
+      activesupport (>= 4.2.0)
     jquery-rails (4.3.5)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
@@ -318,7 +316,6 @@ DEPENDENCIES
   bullet
   byebug
   capybara (>= 2.15)
-  chromedriver-helper
   coffee-rails (~> 5.0)
   database_cleaner
   dotenv-rails


### PR DESCRIPTION
## Changes in this PR

Before this change, running the test suite would produce the following deprecation warning:

```
2020-08-17 17:42:57 WARN Selenium [DEPRECATION] Selenium::WebDriver::Chrome#driver_
path= is deprecated. Use Selenium::WebDriver::Chrome::Service#driver_path= instead.
```

After looking it up it seems to be coming from the chromedriver-helper gem. In following this advice I've removed it and it continues to function:

https://github.com/SeleniumHQ/selenium/issues/7125#issuecomment-486917791

As an additional check I looked at BEIS ODA to see how an app with many more tests is configured. It too has Selenium and has removed this chromedriver-helper gem. This is interesting because that repo was creating using this template.

