### PR TITLE
Add a Coveralls test coverage check to CI

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -26,3 +26,8 @@ jobs:
             -e DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL=true \
             -e DATABASE_URL=postgres://test@pg:5432/app_test \
             app:test bundle exec rake
+      - name: Coveralls
+        uses: coverallsapp/github-action@v1.1.2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-lcov: ./coverage/lcov/app.lcov

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -2,8 +2,11 @@
 # https://github.com/<org>/<repo>/actions
 name: CI
 
-on: pull_request
-
+on:
+  pull_request:
+  push:
+    branches:
+      - main
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -28,7 +28,14 @@ jobs:
             -e RAILS_ENV=test \
             -e DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL=true \
             -e DATABASE_URL=postgres://test@pg:5432/app_test \
+            -v coverage:/srv/app/coverage \
             app:test bundle exec rake
+      - name: DEBUG
+        run: ls -la
+      - name: DEBUG2
+        run: ls -la coverage
+      - name: DEBUG3
+        run: ls -la ./coverage
       - name: Coveralls
         uses: coverallsapp/github-action@v1.1.2
         with:

--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,8 @@ end
 
 group :test do
   gem "capybara", ">= 2.15"
+  gem "simplecov", "~> 0.18"
+  gem "simplecov-lcov"
   gem "selenium-webdriver"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,6 +99,7 @@ GEM
     crass (1.0.6)
     database_cleaner (1.8.5)
     diff-lcs (1.4.4)
+    docile (1.3.2)
     dotenv (2.7.6)
     dotenv-rails (2.7.6)
       dotenv (= 2.7.6)
@@ -261,6 +262,11 @@ GEM
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
     sexp_processor (4.13.0)
+    simplecov (0.19.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+    simplecov-html (0.12.3)
+    simplecov-lcov (0.8.0)
     spring (2.1.1)
     spring-commands-rspec (1.0.4)
       spring (>= 0.9.1)
@@ -335,6 +341,8 @@ DEPENDENCIES
   rspec-rails
   sass-rails (~> 6.0)
   selenium-webdriver
+  simplecov (~> 0.18)
+  simplecov-lcov
   spring
   spring-commands-rspec
   spring-watcher-listen (~> 2.0.0)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+<!--
+  TODO: Replace repo name
+  [![Coverage Status](https://coveralls.io/repos/github/dxw/rails-template/badge.svg?branch=main)](https://coveralls.io/github/dxw/rails-template?branch=main)
+-->
+
 # Using this template
 
 1. Search for `TODO` across the repository to customise the template to the new

--- a/doc/architecture/decisions/0006-use-coveralls-to-monitor-test-coverage.md
+++ b/doc/architecture/decisions/0006-use-coveralls-to-monitor-test-coverage.md
@@ -1,0 +1,20 @@
+# 6. use-coveralls-to-monitor-test-coverage
+
+Date: 2020-10-08
+
+## Status
+
+Accepted
+
+## Context
+
+We want to keep our test coverage as high as possible without having to run manual checks as these take time and are easy to forget.
+
+## Decision
+
+Use the free tier of Coveralls to give us statistics and to give our pull requests feedback.
+
+## Consequences
+
+- The free tier only works on public repositories
+- Pull request feedback should help us spot unexpected reductions in coverage and prompt us to keep it high before we merge

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,7 +19,11 @@
 require "simplecov"
 require "simplecov-lcov"
 SimpleCov::Formatter::LcovFormatter.config.report_with_single_file = true
+SimpleCov::Formatter::LcovFormatter.config do |config|
+  config.single_report_path = "coverage/lcov/app.lcov"
+end
 SimpleCov.formatter = SimpleCov::Formatter::LcovFormatter
+
 SimpleCov.start
 
 RSpec.configure do |config|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,6 +15,13 @@
 # it.
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
+
+require "simplecov"
+require "simplecov-lcov"
+SimpleCov::Formatter::LcovFormatter.config.report_with_single_file = true
+SimpleCov.formatter = SimpleCov::Formatter::LcovFormatter
+SimpleCov.start
+
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->

## Changes in this PR

- the app can now generate a test coverage report in a single lcov file
- CI has a new step to use this coverage report to help surface coverage changes to the pull request checks
- the user will still need to set the project settings within Coveralls and define what is a sensible threshold for them
- CI will now run on pushes to main solely to generate a coverage report that can be used in our readme badge. Deploys don't happen often enough to make this seem like an unreasonable cost?

I would liked to have set a default lower threshold of 98% so the person setting up the repo didn't have to remember. Perhaps by using .coveralls.yml. Sadly I couldn't find a way to do this so if anyone has any ideas they would be welcome :)
