### PR TITLE
Test suite checks code coverage with Simplecov

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,7 @@ end
 group :test do
   gem "capybara", ">= 2.15"
   gem "selenium-webdriver"
+  gem "simplecov"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,6 +99,7 @@ GEM
     crass (1.0.6)
     database_cleaner (1.8.5)
     diff-lcs (1.4.4)
+    docile (1.3.2)
     dotenv (2.7.6)
     dotenv-rails (2.7.6)
       dotenv (= 2.7.6)
@@ -243,6 +244,10 @@ GEM
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
+    simplecov (0.19.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+    simplecov-html (0.12.3)
     spring (2.1.1)
     spring-commands-rspec (1.0.4)
       spring (>= 0.9.1)
@@ -314,6 +319,7 @@ DEPENDENCIES
   rspec-rails
   sass-rails (~> 6.0)
   selenium-webdriver
+  simplecov
   spring
   spring-commands-rspec
   spring-watcher-listen (~> 2.0.0)

--- a/app/channels/application_cable/channel.rb
+++ b/app/channels/application_cable/channel.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
+# TODO: Remove nocov block if this scaffold is extended upon
+# :nocov:
 module ApplicationCable
   class Channel < ActionCable::Channel::Base
   end
 end
+# :nocov:

--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
+# TODO: Remove nocov block if this scaffold is extended upon
+# :nocov:
 module ApplicationCable
   class Connection < ActionCable::Connection::Base
   end
 end
+# :nocov:

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
 
+# TODO: Remove nocov block if this scaffold is extended upon
+# :nocov:
 class ApplicationJob < ActiveJob::Base
 end
+# :nocov:

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
+# TODO: Remove nocov block if this scaffold is extended upon
+# :nocov:
 class ApplicationMailer < ActionMailer::Base
   default from: "from@example.com"
   layout "mailer"
 end
+# :nocov:

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+# TODO: Remove nocov block if this scaffold is extended upon
+# :nocov:
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
 end
+# :nocov:

--- a/doc/architecture/decisions/0006-use-simplecov-to-monitor-code-test-coverage.md
+++ b/doc/architecture/decisions/0006-use-simplecov-to-monitor-code-test-coverage.md
@@ -1,0 +1,30 @@
+# 6. use-coveralls-to-monitor-test-coverage
+
+Date: 2020-10-09
+
+## Status
+
+Accepted
+
+## Context
+
+We want to keep our test coverage as high as possible without having to run
+manual checks as these take time and are easy to forget.
+
+## Decision
+
+Use Simplecov with RSpec to monitor coverage changes on every test run
+
+## Consequences
+
+- Simplecov is not dependent on a third-party service such as Coveralls.io
+- Simplecov can be used on private or public Github repositories
+- Being part of the test suite allows feedback to be providing locally to give
+feedback soon
+- Being part of the test suite allows pull requests to automatically be marked
+as failed and block merging of new code that introduces gaps
+- We have to choose a coverage threshold to return an exit code in order to
+block deploys. The right default value is a matter of opinion however teams can
+easily change it
+- Not using a service like Coveralls means we won't have their features like
+coverage over time, badges, notifications etc

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,6 +15,11 @@
 # it.
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
+
+require "simplecov"
+SimpleCov.minimum_coverage 99
+SimpleCov.start "rails"
+
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->

## Changes in this PR

- use simplecov to do this as part of RSpec
- set threshold to 99% as default
- include ADR
- exclude default Rails files from test coverage to avoid us having to write tests for scaffolding

![Screenshot 2020-10-09 at 11 41 57](https://user-images.githubusercontent.com/912473/95574173-7603e800-0a24-11eb-8e08-6e9c18795ec2.png)