### PR TITLE
Run CI workflow on merges to main or develop

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -2,7 +2,12 @@
 # https://github.com/<org>/<repo>/actions
 name: CI
 
-on: pull_request
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - develop
 
 jobs:
   test:


### PR DESCRIPTION
Previously, CI would only run on pull requests, and not on the result of merging those pull requests. This would mean that downstream automated processes relying on a passing CI result (such as Heroku deployments) would never run.

This change will run CI workflows on all pull requests, and all pushes (including the result of merges) to `develop` and `main`.