### PR TITLE
Cache Docker Image

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -19,12 +19,26 @@ jobs:
         uses: actions/checkout@v2
       - name: Set up Docker
         run: docker network create test
+      - id: cache-docker
+        uses: actions/cache@v2
+        with:
+          path: /tmp/docker-save
+          key:
+            docker-save-${{ hashFiles('Dockerfile', 'Gemfile.lock',
+            'package-lock.json') }}
+      - name: Load cached Docker image
+        run: docker load -i /tmp/docker-save/snapshot.tar || true
+        if: steps.cache-docker.outputs.cache-hit == 'true'
       - name: Set up Postgres
         run:
           docker run -d --name pg --network test -e POSTGRES_USER=test -e
           POSTGRES_HOST_AUTH_METHOD=trust -p 5432:5432 postgres:11
       - name: Build a new Docker image
-        run: docker build . --build-arg RAILS_ENV=test -t app:test
+        run: |
+          docker build . \
+            --build-arg RAILS_ENV=test \
+            -t app:test \
+            --cache-from app:test
       - name: Run the tests
         run: |
           docker run --name test-container \
@@ -33,3 +47,8 @@ jobs:
             -e DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL=true \
             -e DATABASE_URL=postgres://test@pg:5432/app_test \
             app:test bundle exec rake
+      - name: Prepare Docker cache
+        run:
+          mkdir -p /tmp/docker-save && docker save app:test -o
+          /tmp/docker-save/snapshot.tar && ls -lh /tmp/docker-save
+        if: always() && steps.cache-docker.outputs.cache-hit != 'true'


### PR DESCRIPTION
This checks for the existence of a cache if the Docker image or the dependencies have not changed. If there is a cache available, we download and restore it. If there is not, we run the tests, then save and upload the cached image for next time.