### PR TITLE
Whitelist and redirect domains

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,11 @@ ROLLBAR_ENV=development
 
 # TODO: Replace `rails-template` with the name of the app.
 DATABASE_URL=postgres://postgres@localhost:5432/rails-template-development
+
+# TODO: Replace `example.com` with the canonical hostname of the app
+CANONICAL_HOSTNAME=example.com
+
+# TODO: Add a comma seperated list of any other hostnames you want to
+# app to respond to and redirect to the canonical hostname, or delete
+# this line completely
+ADDITIONAL_HOSTNAMES=

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -93,6 +93,15 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
+  # See https://github.com/rails/rails/issues/29893
+  # This only allows hosts the application can trust when using `url_for` and related helpers
+  if ENV["CANONICAL_HOSTNAME"].present?
+    hosts = []
+    hosts << ENV["CANONICAL_HOSTNAME"]
+    hosts += ENV["ADDITIONAL_HOSTNAMES"].split(",").map { |domain| domain } if ENV["ADDITIONAL_HOSTNAMES"].present?
+    config.hosts = hosts.compact
+  end
+
   # Inserts middleware to perform automatic connection switching.
   # The `database_selector` hash is used to pass options to the DatabaseSelector
   # middleware. The `delay` is used to determine how long to wait after a write

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,4 +3,12 @@
 Rails.application.routes.draw do
   get "health_check" => "application#health_check"
   root to: "visitors#index"
+
+  # If the CANONICAL_HOSTNAME env var is present, and the request doesn't come from that
+  # hostname, redirect us to the canonical hostname with the path and query string present
+  if ENV["CANONICAL_HOSTNAME"].present?
+    constraints(host: Regexp.new("^(?!#{Regexp.escape(ENV["CANONICAL_HOSTNAME"])})")) do
+      match "/(*path)" => redirect(host: ENV["CANONICAL_HOSTNAME"]), :via => [:all]
+    end
+  end
 end

--- a/spec/requests/domain_redirect_spec.rb
+++ b/spec/requests/domain_redirect_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+RSpec.describe "Canonical domain redirect", type: :request do
+  before(:all) do
+    ENV["CANONICAL_HOSTNAME"] = "http://example.com"
+    Rails.application.reload_routes!
+  end
+
+  after(:all) do
+    ENV["CANONICAL_HOSTNAME"] = ""
+    Rails.application.reload_routes!
+  end
+
+  it "redirects to the canonical domain" do
+    expect(get("http://example.org/claim/new")).to redirect_to("http://example.com/claim/new")
+    expect(response.status).to eq(301)
+  end
+
+  it "keeps the original path" do
+    expect(get("http://example.org/cookies")).to redirect_to("http://example.com/cookies")
+    expect(response.status).to eq(301)
+  end
+
+  it "keeps query strings in place" do
+    expect(get("http://example.org/cookies?foo=bar")).to redirect_to("http://example.com/cookies?foo=bar")
+    expect(response.status).to eq(301)
+  end
+end


### PR DESCRIPTION
This is a common thing that comes out of pentests, so is worth having across all of our projects. I've also added an env var that allows for additional domains, if we want (for example if we transition from a temporary domain to a service.gov.uk domain, and want to old one to still work) 

I've also added a redirector which will redirect from a secondary domain to the canonical one with the path and query string intact.