### PR TITLE
Create a .dockerignore file from .gitignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,92 @@
+## IMPORTANT ##
+#
+# Usually a pattern here also belongs in your `.gitignore` file and vice versa.
+#
+# Note that Docker's ignore syntax is slightly different to Git's. The main
+# difference is that Git interprets patterns without a leading slash as applying
+# to any subdirectory, while Docker interprets them as relative to the project
+# root directory. To resolve that, a `.dockerignore` should prefix those
+# patterns with `**/`. This is also compatible with Git.
+#
+# This file is NOT a substitute for being intentional in copying directories to
+# a Docker image. Avoid use of `COPY . <destination>` in your `Dockerfile`s.
+#
+## How to use this file
+#
+# Add patterns to the section they apply to, sorted by:
+#
+#   1. absolute paths to or patterns for files (with a `/` prefix)
+#   2. absolute paths to or patterns for directories
+#   3. relative paths to or patterns for files (with a `**/` prefix)
+#   4. relative paths to or patterns for directories
+#   5. pattern exceptions (sorted as above)
+#
+# Sort them alphanumerically within each section.
+#
+# If no section fits, create one. No path or pattern should exist without a
+# section or label.
+#
+
+## Sensitive files
+#
+# Note that these patterns will ignore any files matched by their equivalents in
+# `.gitignore`. This is probably what you want in many cases, but you may need
+# to add exceptions here if you really want to include them in your Docker
+# images. An exception is a more specific pattern (ideally a fully specified
+# path without any wildcards) prefixed with a `!` and must be defined after the
+# pattern it's excepting (which will happen naturally if you're following the
+# sort order above).
+#
+### Databases
+**/*.db*
+**/*.dump*
+**/*.sql*
+**/*.sqlite3*
+### Environment variables
+**/.env
+**/.env.*
+### Logs
+**/*.log*
+### Secrets and keys
+**/*.crt*
+**/*.key*
+**/*.pem*
+### Spreadsheet data
+**/*.bks*
+**/*.csv*
+**/*.dex*
+**/*.numbers*
+**/*.ods*
+**/*.ots*
+**/*.tsv*
+**/*.xlr*
+**/*.xls*
+### Terraform
+**/.terraformrc*
+**/terraform.rc*
+**/*.tfstate*
+**/*.tfvars*
+**/.terraform/
+### XML data
+**/*.xml*
+
+## Dependencies
+/Brewfile.lock.json
+/.bundle/
+/node_modules/
+/vendor/bundle/
+
+## Temporary files
+/coverage/
+/log/
+**/tmp/
+
+## Build artefacts
+/public/assets/
+
+## Docker specific patterns ##
+#
+### Dependencies
+/Brewfile
+### Workflow configuration
+/.github/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,14 @@
+## IMPORTANT ##
+#
+# Usually a pattern here also belongs in your `.dockerignore` file and vice
+# versa.
+#
+# Note that Docker's ignore syntax is slightly different to Git's. The main
+# difference is that Git interprets patterns without a leading slash as applying
+# to any subdirectory, while Docker interprets them as relative to the project
+# root directory. To resolve that, a `.dockerignore` should prefix those
+# patterns with `**/`. This is also compatible with Git.
+#
 ## How to use this file
 #
 # Add patterns to the section they apply to, sorted by:


### PR DESCRIPTION
Most of the rules will be the same in both files, but there are some syntax differences and additional rules or exceptions to make for a Docker image, so we can't use a symlink. Instead we add some documentation guidance to remind people to update both places and about the differences between them.