### PR TITLE
Prevent accidental disclosure of sensitive files during development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-FROM ruby:2.7.2 as release
+# ------------------------------------------------------------------------------
+# Base
+# ------------------------------------------------------------------------------
+FROM ruby:2.7.2 as base
 MAINTAINER dxw <rails@dxw.com>
 
 RUN curl -sL https://deb.nodesource.com/setup_10.x | bash
@@ -8,60 +11,79 @@ RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources
 RUN apt-get update && apt-get install -qq -y \
   build-essential \
   libpq-dev \
-  nodejs \
-  yarn \
-  shellcheck \
   --fix-missing --no-install-recommends
 
-ENV INSTALL_PATH /srv/app
-RUN mkdir -p $INSTALL_PATH
+ENV APP_HOME /srv/app
+ENV DEPS_HOME /deps
 
-WORKDIR $INSTALL_PATH
-
-# set rails environment
 ARG RAILS_ENV
-ENV RAILS_ENV=${RAILS_ENV:-production}
-ENV RACK_ENV=${RAILS_ENV:-production}
+ENV RAILS_ENV ${RAILS_ENV:-production}
+ENV NODE_ENV ${RAILS_ENV:-production}
+
+# ------------------------------------------------------------------------------
+# Dependencies
+# ------------------------------------------------------------------------------
+FROM base AS dependencies
+
+RUN mkdir -p ${DEPS_HOME}
+WORKDIR $DEPS_HOME
+
+RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - \
+  && apt-get install -y nodejs \
+  && npm install --global yarn
 
 # Install Javascript dependencies
-COPY yarn.lock $INSTALL_PATH/yarn.lock
-COPY package.json $INSTALL_PATH/package.json
+COPY yarn.lock $DEPS_HOME/yarn.lock
+COPY package.json $DEPS_HOME/package.json
 RUN yarn install
 
 # Install Ruby dependencies
-COPY Gemfile $INSTALL_PATH/Gemfile
-COPY Gemfile.lock $INSTALL_PATH/Gemfile.lock
+COPY Gemfile $DEPS_HOME/Gemfile
+COPY Gemfile.lock $DEPS_HOME/Gemfile.lock
 RUN gem update --system
-RUN gem install bundler
+RUN gem install bundler -v 2.2.16
 
 ENV BUNDLE_GEM_GROUPS=$RAILS_ENV
+RUN bundle config set frozen "true"
 RUN bundle config set no-cache "true"
 RUN bundle config set with $BUNDLE_GEM_GROUPS
 RUN bundle install --retry=10 --jobs=4
 
+# ------------------------------------------------------------------------------
+# Web
+# ------------------------------------------------------------------------------
+FROM dependencies AS web
+
+RUN mkdir -p ${APP_HOME}
+WORKDIR ${APP_HOME}
+
 # Copy app code (sorted by vague frequency of change for caching)
-RUN mkdir -p ${INSTALL_PATH}/log
-RUN mkdir -p ${INSTALL_PATH}/tmp
+RUN mkdir -p ${APP_HOME}/log
+RUN mkdir -p ${APP_HOME}/tmp
 
-COPY config.ru ${INSTALL_PATH}/config.ru
-COPY Rakefile ${INSTALL_PATH}/Rakefile
+COPY config.ru ${APP_HOME}/config.ru
+COPY Rakefile ${APP_HOME}/Rakefile
 
-COPY /.eslintignore ${INSTALL_PATH}/.eslintignore
-COPY .eslintrc.json ${INSTALL_PATH}/.eslintrc.json
-COPY .prettierignore ${INSTALL_PATH}/.prettierignore
-COPY .prettierrc ${INSTALL_PATH}/.prettierrc
+COPY Gemfile $APP_HOME/Gemfile
+COPY Gemfile.lock $APP_HOME/Gemfile.lock
 
-COPY public ${INSTALL_PATH}/public
-COPY vendor ${INSTALL_PATH}/vendor
-COPY bin ${INSTALL_PATH}/bin
-COPY lib ${INSTALL_PATH}/lib
-COPY config ${INSTALL_PATH}/config
-COPY db ${INSTALL_PATH}/db
-COPY script ${INSTALL_PATH}/script
-COPY app ${INSTALL_PATH}/app
+COPY public ${APP_HOME}/public
+COPY vendor ${APP_HOME}/vendor
+COPY bin ${APP_HOME}/bin
+COPY lib ${APP_HOME}/lib
+COPY config ${APP_HOME}/config
+COPY db ${APP_HOME}/db
+COPY script ${APP_HOME}/script
+COPY app ${APP_HOME}/app
 # End
 
-RUN RAILS_ENV=$RAILS_ENV SECRET_KEY_BASE="super secret" bundle exec rake assets:precompile --quiet
+# Create tmp/pids
+RUN mkdir -p tmp/pids
+
+# This must be ordered before rake assets:precompile
+RUN cp -R $DEPS_HOME/node_modules $APP_HOME/node_modules
+
+RUN RAILS_ENV=$RAILS_ENV SECRET_KEY_BASE="secret" bundle exec rake assets:precompile --quiet
 
 # TODO:
 # In order to expose the current git sha & time of build in the /healthcheck
@@ -81,4 +103,22 @@ ENTRYPOINT ["/docker-entrypoint.sh"]
 
 EXPOSE 3000
 
-CMD ["rails", "server"]
+CMD ["bundle", "exec", "rails", "server"]
+
+# ------------------------------------------------------------------------------
+# Test
+# ------------------------------------------------------------------------------
+FROM web as test
+
+RUN apt-get install -qq -y shellcheck
+
+COPY package.json ${APP_HOME}/package.json
+COPY yarn.lock ${APP_HOME}/yarn.lock
+
+COPY .eslintignore ${APP_HOME}/.eslintignore
+COPY .eslintrc.json ${APP_HOME}/.eslintrc.json
+COPY .prettierignore ${APP_HOME}/.prettierignore
+COPY .prettierrc ${APP_HOME}/.prettierrc
+
+COPY .rspec ${APP_HOME}/.rspec
+COPY spec ${APP_HOME}/spec

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -3,6 +3,7 @@ services:
   test:
     build:
       context: .
+      target: test
       args:
         RAILS_ENV: "test"
       cache_from:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -3,6 +3,7 @@ services:
   test:
     build:
       context: .
+      target: test
       args:
         RAILS_ENV: "test"
     command: bundle exec rake

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ services:
   web:
     build:
       context: .
+      target: web
       args:
         RAILS_ENV: "development"
     command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'"


### PR DESCRIPTION
Based atop https://github.com/dxw/rails-template/pull/213

## Changes in this PR

- preventing accidental disclosure
- refactor Dockerfile into multi-stage builds. This allows us to `COPY` all the extra files needed for testing into an isolated stage. This allows us to separate copied files needed for the app in prod from those needed only for test

## Preventing accidental disclosure

As an action from an incident on DfE Schools Buying we would like to push this change upstream.

Using `COPY . .` is problematic as it could (and has) quietly included sensitive files such as `.env` which was then pushed to a Docker registry. This allows anyone who pulls that image to read the contents are get hold of secrets etc.

Instead of doing this we can change to a whitelist approach. Including only the folders we expect for a Rails project. These should remain static and perhaps only change during major Rails releases.

A `.dockerignore` file does already exist as a mechanism to achieve the same result however it requires a human to rememeber to configure it properly -  steps have also been made to improve this file by default [1]. This Dockerfile change is therefore aimed at provided more defence in depth to help prevent accidental disclosure of sensitive files.

We are using this in production already at least on DfE Schools Buying [2] and DfE Claim [3].


[1] https://github.com/dxw/rails-template/pull/198
[2] https://github.com/DFE-Digital/buy-for-your-school/blob/develop/Dockerfile#L33
[3] https://github.com/DFE-Digital/claim-additional-payments-for-teaching/blob/master/Dockerfile#L101


## Next steps

Move the incident action card to done https://trello.com/c/A8DBTFbM