### PR TITLE
Run the app locally and on CI using docker compose

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,3 +2,4 @@
 /tmp/
 /vendor/
 /public/assets
+/coverage

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -17,8 +17,6 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v2
-      - name: Set up Docker
-        run: docker network create test
       - id: cache-docker
         uses: actions/cache@v2
         with:
@@ -29,27 +27,12 @@ jobs:
       - name: Load cached Docker image
         run: docker load -i /tmp/docker-save/snapshot.tar || true
         if: steps.cache-docker.outputs.cache-hit == 'true'
-      - name: Set up Postgres
-        run:
-          docker run -d --name pg --network test -e POSTGRES_USER=test -e
-          POSTGRES_HOST_AUTH_METHOD=trust -p 5432:5432 postgres:11
-      - name: Build a new Docker image
-        run: |
-          docker build . \
-            --build-arg RAILS_ENV=test \
-            -t app:test \
-            --cache-from app:test
-      - name: Run the tests
-        run: |
-          docker run --name test-container \
-            --network test \
-            -e RAILS_ENV=test \
-            -e DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL=true \
-            -e DATABASE_URL=postgres://test@pg:5432/app_test \
-            -e CI=true \
-            app:test script/test
+      - name: Build
+        run: docker-compose -f docker-compose.ci.yml build
+      - name: Test
+        run: docker-compose -f docker-compose.ci.yml run --rm test script/test
       - name: Prepare Docker cache
         run:
-          mkdir -p /tmp/docker-save && docker save app:test -o
+          mkdir -p /tmp/docker-save && docker save rails-template_test:latest -o
           /tmp/docker-save/snapshot.tar && ls -lh /tmp/docker-save
         if: always() && steps.cache-docker.outputs.cache-hit != 'true'

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -28,11 +28,11 @@ jobs:
         run: docker load -i /tmp/docker-save/snapshot.tar || true
         if: steps.cache-docker.outputs.cache-hit == 'true'
       - name: Build
-        run: docker-compose -f docker-compose.ci.yml build
+        run: docker-compose -f docker-compose.ci.yml -p app build
       - name: Test
         run: docker-compose -f docker-compose.ci.yml run --rm test script/test
       - name: Prepare Docker cache
         run:
-          mkdir -p /tmp/docker-save && docker save rails-template_test:latest -o
+          mkdir -p /tmp/docker-save && docker save app_test:latest -o
           /tmp/docker-save/snapshot.tar && ls -lh /tmp/docker-save
         if: always() && steps.cache-docker.outputs.cache-hit != 'true'

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -28,9 +28,9 @@ jobs:
         run: docker load -i /tmp/docker-save/snapshot.tar || true
         if: steps.cache-docker.outputs.cache-hit == 'true'
       - name: Build
-        run: docker-compose -f docker-compose.ci.yml -p app build
+        run: script/ci/cibuild
       - name: Test
-        run: docker-compose -f docker-compose.ci.yml run --rm test script/test
+        run: script/ci/test
       - name: Prepare Docker cache
         run:
           mkdir -p /tmp/docker-save && docker save app_test:latest -o

--- a/.prettierignore
+++ b/.prettierignore
@@ -25,3 +25,4 @@
 *.txt
 *.gz
 /public/assets/*
+/coverage

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,14 +29,10 @@ COPY Gemfile.lock $INSTALL_PATH/Gemfile.lock
 RUN gem update --system
 RUN gem install bundler
 
-# bundle ruby gems based on the current environment, default to production
-RUN echo $RAILS_ENV
-RUN \
-  if [ "$RAILS_ENV" = "production" ]; then \
-    bundle install --without development test --retry 10; \
-  else \
-    bundle install --retry 10; \
-  fi
+ENV BUNDLE_GEM_GROUPS=$RAILS_ENV
+RUN bundle config set no-cache "true"
+RUN bundle config set with $BUNDLE_GEM_GROUPS
+RUN bundle install --retry=10 --jobs=4
 
 COPY . $INSTALL_PATH
 

--- a/README.md
+++ b/README.md
@@ -33,31 +33,7 @@ TODO: replace README header with project name
 
 TODO: Add a summary of who the application is for and what it will do.
 
-## Getting started
-
-Run the setup script:
-
-```bash
-$ script/server
-```
-
-Run the tests:
-
-```bash
-$ script/setup
-```
-
-Start the server:
-
-```bash
-$ script/server
-```
-
-Start a console:
-
-```bash
-$ script/console
-```
+1. [Getting started](/doc/getting-started.md)
 
 ## Static code analysis
 

--- a/README.md
+++ b/README.md
@@ -38,25 +38,25 @@ TODO: Add a summary of who the application is for and what it will do.
 Run the setup script:
 
 ```bash
-script/setup
+$ script/server
 ```
 
 Run the tests:
 
 ```bash
-script/test
+$ script/setup
 ```
 
 Start the server:
 
 ```bash
-script/server
+$ script/server
 ```
 
 Start a console:
 
 ```bash
-script/console
+$ script/console
 ```
 
 ## Static code analysis
@@ -65,13 +65,13 @@ Run [Brakeman](https://brakemanscanner.org/) to highlight any security
 vulnerabilities:
 
 ```bash
-brakeman
+$ brakeman
 ```
 
 To pipe the results to a file:
 
 ```bash
-brakeman -o report.text
+$ brakeman -o report.text
 ```
 
 ## Making changes

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -45,3 +45,31 @@ Running the tests regularly should be done without Docker as it is much faster.
 ```bash
 $ brew install --cask docker
 ```
+
+### Usage
+
+#### Occassional use
+
+Use the `--docker` switch:
+
+```bash
+$ script/test --docker
+```
+
+#### Regular use
+
+You can set `PREFER_DOCKER_FOR_DXW_RAILS=1` in your env to set this preference
+automatically.
+
+- Option 1:
+  - Install and use
+    [direnv to set an environment variable on a per codebase basis](https://direnv.net/)
+  - Add `PREFER_DOCKER_FOR_DXW_RAILS=1` to your `.envrc`
+  - Load change with `direnv allow .`
+- Option 2:
+  - Set `PREFER_DOCKER_FOR_DXW_RAILS=1` in your global `.zshrc` or `.bashrc`
+  - Load your change with `source .zshrc`
+
+Switches will take priority over any default preference. For example, with
+`PREFER_DOCKER_FOR_DXW_RAILS=1` set you can run `--no-docker` to run without
+Docker.

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -1,0 +1,47 @@
+# Getting started
+
+We use the
+["Scripts To Rule Them All"](https://github.com/dxw/tech-team-rfcs/blob/main/rfc-023-use-scripts-to-rule-them-all.md)
+pattern to standardise the common commands we have to use.
+
+Setup the application:
+
+```bash
+$ script/setup
+```
+
+Start the server:
+
+```bash
+$ script/server
+```
+
+Start a console:
+
+```bash
+$ script/console
+```
+
+Run the tests:
+
+```bash
+$ script/test
+```
+
+Update application to run for its current checkout:
+
+```bash
+$ script/update
+```
+
+## With Docker
+
+Docker is made available to run these commands locally as containerisation [MUST be used on CI and SHOULD be used on live environments](https://github.com/dxw/tech-team-rfcs/blob/main/rfc-013-use-docker-to-deploy-and-run-applications-in-containers.md). Using Docker locally provides the strongest parity between development and live. It can also be more stable to get running on your machine.
+
+Running the tests regularly should be done without Docker as it is much faster.
+
+### Prerequisites
+
+```bash
+$ brew install --cask docker
+```

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,0 +1,37 @@
+version: "3.8"
+services:
+  test:
+    build:
+      context: .
+      args:
+        RAILS_ENV: "test"
+    command: bundle exec rake
+    ports:
+      - "3000:3000"
+    depends_on:
+      - test-db
+    env_file:
+       - .env.test
+    environment:
+      DATABASE_URL: postgres://postgres:password@test-db:5432/app-test
+      DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL: "true"
+      SECRET_KEY_BASE: secret
+      CI: "true"
+    networks:
+      - test
+
+  test-db:
+    image: postgres
+    volumes:
+      - db-data:/var/lib/postgresql/data
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: password
+      POSTGRES_HOST_AUTH_METHOD: trust
+    networks:
+      - test
+
+networks:
+  test:
+volumes:
+  db-data:

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -20,6 +20,7 @@ services:
       DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL: "true"
       SECRET_KEY_BASE: secret
       CI: "true"
+      AUTOMATICALLY_FIX_LINTING: "false"
     networks:
       - test
 

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -5,6 +5,9 @@ services:
       context: .
       args:
         RAILS_ENV: "test"
+      cache_from:
+        - app_test:latest
+    image: app_test
     command: bundle exec rake
     ports:
       - "3000:3000"

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -15,6 +15,7 @@ services:
     environment:
       DATABASE_URL: postgres://postgres:password@test-db:5432/app-test
       DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL: "true"
+      AUTOMATICALLY_FIX_LINTING: "true"
     volumes:
       - .:/srv/app
     tty: true

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,39 @@
+version: "3.8"
+services:
+  test:
+    build:
+      context: .
+      args:
+        RAILS_ENV: "test"
+    command: bundle exec rake
+    ports:
+      - "3000:3000"
+    depends_on:
+      - test-db
+    env_file:
+       - .env.test
+    environment:
+      DATABASE_URL: postgres://postgres:password@test-db:5432/app-test
+      DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL: "true"
+    volumes:
+      - .:/srv/app
+    tty: true
+    stdin_open: true
+    networks:
+      - test
+
+  test-db:
+    image: postgres
+    volumes:
+      - db-data:/var/lib/postgresql/data
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: password
+      POSTGRES_HOST_AUTH_METHOD: trust
+    networks:
+      - test
+
+networks:
+  test:
+volumes:
+  db-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
     environment:
       # TODO: Update rails-template with application name
       DATABASE_URL: postgres://postgres:password@db:5432/rails-template-development
+      AUTOMATICALLY_FIX_LINTING: "true"
     volumes:
       - .:/srv/app
     tty: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,39 @@
+version: "3.8"
+services:
+  web:
+    build:
+      context: .
+      args:
+        RAILS_ENV: "development"
+    command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'"
+    ports:
+      - "3000:3000"
+    depends_on:
+      - db
+    env_file:
+       - .env.development.local
+    environment:
+      # TODO: Update rails-template with application name
+      DATABASE_URL: postgres://postgres:password@db:5432/rails-template-development
+    volumes:
+      - .:/srv/app
+    tty: true
+    stdin_open: true
+    networks:
+      - dev
+
+  db:
+    image: postgres
+    volumes:
+      - db-data:/var/lib/postgresql/data
+    environment:
+      POSTGRES_PASSWORD: password
+      POSTGRES_HOST_AUTH_METHOD: trust
+    networks:
+      - dev
+
+networks:
+  dev:
+
+volumes:
+  db-data:

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -5,60 +5,13 @@
 
 set -e
 
+# Enable the running of this script from any subdirectory without moving to root
 cd "$(dirname "$0")/.."
 
-if [ -f .gitmodules ]; then
-  echo "==> Updating Git submodules..."
-  git submodule update --init
-fi
-
-if [ -z "$CI" ]; then
-  if [ -f Brewfile ] && [ "$(uname -s)" = "Darwin" ]; then
-    if ! brew bundle check >/dev/null 2>&1; then
-      echo "==> Installing Homebrew dependencies..."
-      brew bundle install --verbose --no-lock
-    fi
-  fi
-
-  if [ -f .ruby-version ]; then
-    eval "$(rbenv init -)"
-
-    if [ -z "$(rbenv version-name 2>/dev/null)" ]; then
-      echo "==> Installing Ruby..."
-      rbenv install --skip-existing
-      rbenv rehash
-    fi
-  fi
-
-  if [ -f .node-version ]; then
-    eval "$(nodenv init -)"
-
-    if [ -z "$(nodenv version-name 2>/dev/null)" ]; then
-      echo "==> Installing Node..."
-      nodenv install --skip-existing
-      nodenv rehash
-    fi
-  fi
-fi
-
-if ! command -v bundle >/dev/null 2>&1; then
-  echo "==> Installing Bundler..."
-  gem install bundler
-
-  if [ -z "$CI" ]; then
-    rbenv rehash
-  fi
-fi
-
-if ! bundle check >/dev/null 2>&1; then
-  echo "==> Installing Ruby dependencies..."
-  bundle config set path vendor/bundle
-  bundle install
-fi
-
-if [ -f package.json ]; then
-  if ! yarn check --verify-tree >/dev/null 2>&1; then
-    echo "==> Installing JS dependencies..."
-    yarn install
-  fi
+if [ "$DOCKER" ]; then
+  echo "==> Running with Docker..."
+  script/docker/bootstrap "$@"
+else
+  echo "==> Running natively (no docker)..."
+  script/no-docker/bootstrap "$@"
 fi

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -8,7 +8,22 @@ set -e
 # Enable the running of this script from any subdirectory without moving to root
 cd "$(dirname "$0")/.."
 
-if [ "$DOCKER" ]; then
+echo "==> Loading command line options…"
+DOCKER=${PREFER_DOCKER_FOR_DXW_RAILS:-0}
+for arg in "$@"
+do
+  case $arg in
+    --docker)
+      DOCKER=1
+      ;;
+    --no-docker)
+      DOCKER=0
+      ;;
+  esac
+  shift
+done
+
+if [ "$DOCKER" -eq 1 ]; then
   echo "==> Running with Docker..."
   script/docker/bootstrap "$@"
 else

--- a/script/ci/cibuild
+++ b/script/ci/cibuild
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# Setup environment for CI to run tests. This is primarily designed to run on
+# the continuous integration server.
+
+set -e
+
+docker-compose -f docker-compose.ci.yml -p app build

--- a/script/ci/test
+++ b/script/ci/test
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# Run the test suite for the application. This is primarily designed to run on
+# CI with a clean build context. To run locally first remove any generic image
+# by running `docker rmi app:latest`
+
+set -e
+
+docker-compose -f docker-compose.ci.yml \
+               -p app \
+               run --rm test \
+               script/run_all_tests "$@"

--- a/script/console
+++ b/script/console
@@ -1,25 +1,23 @@
 #!/bin/sh
 
-# script/console: Launch a console for the application. Optionally pass in an
-#                 environment name to connect to a console for that environment.
+# script/console: Launch a console for the application. Use variables to control
+#                 how you want to provision your local environment.
+#                 Eg. `DOCKER=true script/console`
+#                 Or, add this as a global variable to your shell so it's set
+#                 automatically.
 
 set -e
 
+# Enable the running of this script from any subdirectory without moving to root
 cd "$(dirname "$0")/.."
 
-ENVIRONMENT=$1
-
-if [ -n "$ENVIRONMENT" ]; then
-  case "$ENVIRONMENT" in
-    *)
-      echo "Unknown environment '$ENVIRONMENT'"
-      exit 1
-      ;;
-  esac
+if [ "$CI" ]; then
+  echo "==> Running as CI..."
+  script/ci/console
+elif [ "$DOCKER" ]; then
+  echo "==> Running with Docker..."
+  script/docker/console
 else
-  echo "==> Updating..."
-  script/update
-
-  echo "==> Starting a local Rails console..."
-  bundle exec rails console
+  echo "==> Running natively (no docker)..."
+  script/no-docker/console
 fi

--- a/script/console
+++ b/script/console
@@ -2,7 +2,7 @@
 
 # script/console: Launch a console for the application. Use variables to control
 #                 how you want to provision your local environment.
-#                 Eg. `DOCKER=true script/console`
+#                 Eg. `script/console --docker`
 #                 Or, add this as a global variable to your shell so it's set
 #                 automatically.
 
@@ -11,10 +11,26 @@ set -e
 # Enable the running of this script from any subdirectory without moving to root
 cd "$(dirname "$0")/.."
 
+echo "==> Loading command line options…"
+DOCKER=${PREFER_DOCKER_FOR_DXW_RAILS:-0}
+for arg in "$@"
+do
+  case $arg in
+    --docker)
+      DOCKER=1
+      shift
+      ;;
+    --no-docker)
+      DOCKER=0
+      shift
+      ;;
+  esac
+done
+
 if [ "$CI" ]; then
   echo "==> Running as CI..."
   script/ci/console
-elif [ "$DOCKER" ]; then
+elif [ "$DOCKER" -eq 1 ]; then
   echo "==> Running with Docker..."
   script/docker/console
 else

--- a/script/docker/bootstrap
+++ b/script/docker/bootstrap
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# Resolve all dependencies that the application requires to run.
+
+set -e
+
+# Enable the running of this script from any subdirectory without moving to root
+cd "$(dirname "$0")/../.."
+
+echo "==> Rebuilding Docker image to provision all dependencies..."
+docker-compose build web

--- a/script/docker/console
+++ b/script/docker/console
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# Launch a console for the application alongside any other required processes
+# inside Docker containers
+
+set -e
+
+# Enable the running of this script from any subdirectory without moving to root
+cd "$(dirname "$0")/../.."
+
+docker-compose run --rm web bundle exec rails console

--- a/script/docker/server
+++ b/script/docker/server
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+# Launch the application and any extra required processes locally in docker
+# containers.
+
+set -e
+
+# Enable the running of this script from any subdirectory without moving to root
+cd "$(dirname "$0")/../.."
+
+# INFO: To enable debug prompts (with pry or byebug) we first start the process
+# in the background and then use attach to create an interactive prompt.
+docker-compose up --detach
+
+# TODO: Repace 'rails-template' with application name
+docker attach rails-template_web_1

--- a/script/docker/setup
+++ b/script/docker/setup
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+# Set up the application for the first time after cloning, or set it back to the
+# initial unused state.
+
+set -e
+
+# Enable the running of this script from any subdirectory without moving to root
+cd "$(dirname "$0")/../.."
+
+echo "==> Tearing down any previous application state..."
+docker-compose down -v
+
+script/bootstrap

--- a/script/docker/test
+++ b/script/docker/test
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# Run the test suite for the application in docker containers.
+
+set -e
+
+# Enable the running of this script from any subdirectory without moving to root
+cd "$(dirname "$0")/../.."
+
+docker-compose -f docker-compose.test.yml \
+               run --rm test \
+               script/run_all_tests "$@"

--- a/script/docker/update
+++ b/script/docker/update
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# Update application to run for its current checkout.
+
+set -e
+
+# Enable the running of this script from any subdirectory without moving to root
+cd "$(dirname "$0")/../.."
+
+echo "==> Rebuilding Docker image in order to bundle new gems..."
+docker-compose build web

--- a/script/no-docker/bootstrap
+++ b/script/no-docker/bootstrap
@@ -1,0 +1,64 @@
+#!/bin/sh
+
+# Resolve all dependencies that the application requires to run.
+
+set -e
+
+# Enable the running of this script from any subdirectory without moving to root
+cd "$(dirname "$0")/../.."
+
+if [ -f .gitmodules ]; then
+  echo "==> Updating Git submodules..."
+  git submodule update --init
+fi
+
+if [ -z "$CI" ]; then
+  if [ -f Brewfile ] && [ "$(uname -s)" = "Darwin" ]; then
+    if ! brew bundle check >/dev/null 2>&1; then
+      echo "==> Installing Homebrew dependencies..."
+      brew bundle install --verbose --no-lock
+    fi
+  fi
+
+  if [ -f .ruby-version ]; then
+    eval "$(rbenv init -)"
+
+    if [ -z "$(rbenv version-name 2>/dev/null)" ]; then
+      echo "==> Installing Ruby..."
+      rbenv install --skip-existing
+      rbenv rehash
+    fi
+  fi
+
+  if [ -f .node-version ]; then
+    eval "$(nodenv init -)"
+
+    if [ -z "$(nodenv version-name 2>/dev/null)" ]; then
+      echo "==> Installing Node..."
+      nodenv install --skip-existing
+      nodenv rehash
+    fi
+  fi
+fi
+
+if ! command -v bundle >/dev/null 2>&1; then
+  echo "==> Installing Bundler..."
+  gem install bundler
+
+  if [ -z "$CI" ]; then
+    rbenv rehash
+  fi
+fi
+
+if ! bundle check >/dev/null 2>&1; then
+  echo "==> Installing Ruby dependencies..."
+  bundle config set path vendor/bundle
+  bundle install
+fi
+
+if [ -f package.json ]; then
+  if ! yarn check --verify-tree >/dev/null 2>&1; then
+    echo "==> Installing JS dependencies..."
+    yarn install
+  fi
+fi

--- a/script/no-docker/console
+++ b/script/no-docker/console
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+# Launch a console for the application. Optionally pass in an environment name
+# to connect to a console for that environment.
+
+set -e
+
+# Enable the running of this script from any subdirectory without moving to root
+cd "$(dirname "$0")/../.."
+
+ENVIRONMENT=$1
+
+if [ -n "$ENVIRONMENT" ]; then
+  case "$ENVIRONMENT" in
+    *)
+      echo "Unknown environment '$ENVIRONMENT'"
+      exit 1
+      ;;
+  esac
+else
+  echo "==> Updating..."
+  script/no-docker/update
+
+  echo "==> Starting a local Rails console..."
+  bundle exec rails console
+fi

--- a/script/no-docker/server
+++ b/script/no-docker/server
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+# Launch the application and any extra required processes locally.
+
+set -e
+
+# Enable the running of this script from any subdirectory without moving to root
+cd "$(dirname "$0")/../.."
+
+echo "==> Updating..."
+script/no-docker/update
+
+echo "==> Starting the development server..."
+bundle exec rails server

--- a/script/no-docker/setup
+++ b/script/no-docker/setup
@@ -1,0 +1,61 @@
+#!/bin/sh
+
+# Set up the application for the first time after cloning, or set it back to the
+# initial unused state.
+
+set -e
+
+# Enable the running of this script from any subdirectory without moving to root
+cd "$(dirname "$0")/../.."
+
+if [ -d vendor/bundle ]; then
+  echo "==> Cleaning installed Ruby dependencies..."
+  git clean -x --force -- vendor/bundle
+fi
+
+echo "==> Bootstrapping..."
+script/no-docker/bootstrap
+
+echo "==> Dropping database..."
+set +e
+bundle exec rails db:drop
+DB_DROP_RESULT=$?
+set -e
+
+if [ -z "$CI" ] && [ -n "$DB_DROP_RESULT" ]; then
+  printf "\\nDatabase drop failed. Continue anyway? [y/N] "
+  read -r
+
+  case $REPLY in
+    y | Y)
+      ;;
+    *)
+      exit 1
+      ;;
+  esac
+fi
+
+echo "==> Creating database..."
+bundle exec rails db:setup
+
+echo "==> Dropping test database..."
+set +e
+RAILS_ENV="test" bundle exec rails db:drop
+DB_DROP_RESULT=$?
+set -e
+
+if [ -z "$CI" ] && [ -n "$DB_DROP_RESULT" ]; then
+  printf "\\nDatabase drop failed. Continue anyway? [y/N] "
+  read -r
+
+  case $REPLY in
+    y | Y)
+      ;;
+    *)
+      exit 1
+      ;;
+  esac
+fi
+
+echo "==> Creating test database..."
+RAILS_ENV="test" bundle exec rails db:setup

--- a/script/no-docker/test
+++ b/script/no-docker/test
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+# Run the test suite for the application. Optionally pass in a path to an
+# individual test file to run a single test.
+
+set -e
+
+# Enable the running of this script from any subdirectory without moving to root
+cd "$(dirname "$0")/../.."
+
+if [ -n "$DEBUG" ]; then
+  set -x
+fi
+
+echo "==> Updating..."
+script/no-docker/update
+
+AUTOMATICALLY_FIX_LINTING=true script/run_all_tests "$@"

--- a/script/no-docker/update
+++ b/script/no-docker/update
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+# Update application to run for its current checkout.
+
+set -e
+
+echo "==> Bootstrapping..."
+script/no-docker/bootstrap
+
+echo "==> Running database migrations..."
+bundle exec rails db:migrate
+
+echo "==> Running test database migrations..."
+RAILS_ENV="test" bundle exec rails db:migrate

--- a/script/run_all_tests
+++ b/script/run_all_tests
@@ -1,0 +1,47 @@
+#!/bin/sh
+
+# Run the test suite for the application. Optionally pass in a path to an
+# individual test file to run a single test.
+
+TEST_FILE=$1
+
+if [ -n "$TEST_FILE" ]; then
+  echo "==> Running the tests matching '$TEST_FILE'..."
+  bundle exec rspec --pattern "$TEST_FILE"
+else
+  if [ -n "$AUTOMATICALLY_FIX_LINTING" ]; then
+    echo "==> Formatting files..."
+    yarn run lint:format:fix
+  else
+    echo "==> Checking formatting..."
+    yarn run lint:format
+  fi
+
+  echo "==> Running ShellCheck..."
+  for file in $(git ls-files script/*)
+  do
+    shellcheck $file
+  done
+
+  if [ -n "$AUTOMATICALLY_FIX_LINTING" ]; then
+    echo "==> Linting Ruby in fix mode..."
+    bundle exec standardrb --fix
+  else
+    echo "==> Linting Ruby..."
+    bundle exec standardrb
+  fi
+
+  if [ -n "$AUTOMATICALLY_FIX_LINTING" ]; then
+    echo "==> Linting JS in fix mode..."
+    yarn run lint:js:fix
+  else
+    echo "==> Linting JS..."
+    yarn run lint:js
+  fi
+
+  echo "==> Running the tests..."
+  bundle exec rspec
+
+  echo "==> Running Brakeman..."
+  bundle exec brakeman -o /dev/stdout
+fi

--- a/script/run_all_tests
+++ b/script/run_all_tests
@@ -3,11 +3,11 @@
 # Run the test suite for the application. Optionally pass in a path to an
 # individual test file to run a single test.
 
-TEST_FILE=$1
+TEST_FILES=$1
 
-if [ -n "$TEST_FILE" ]; then
-  echo "==> Running the tests matching '$TEST_FILE'..."
-  bundle exec rspec --pattern "$TEST_FILE"
+if [ -n "$TEST_FILES" ]; then
+  echo "==> Running the tests matching '$TEST_FILES'..."
+  bundle exec rspec "$TEST_FILES"
 else
   if [ -n "$AUTOMATICALLY_FIX_LINTING" ]; then
     echo "==> Formatting files..."

--- a/script/server
+++ b/script/server
@@ -12,10 +12,25 @@ set -e
 # Enable the running of this script from any subdirectory without moving to root
 cd "$(dirname "$0")/.."
 
+echo "==> Loading command line options…"
+DOCKER=${PREFER_DOCKER_FOR_DXW_RAILS:-0}
+for arg in "$@"
+do
+  case $arg in
+    --docker)
+      DOCKER=1
+      ;;
+    --no-docker)
+      DOCKER=0
+      ;;
+  esac
+  shift
+done
+
 if [ "$CI" ]; then
   echo "==> Running as CI..."
   script/ci/server
-elif [ "$DOCKER" ]; then
+elif [ "$DOCKER" -eq 1 ]; then
   echo "==> Running with Docker..."
   script/docker/server
 else

--- a/script/server
+++ b/script/server
@@ -1,14 +1,24 @@
 #!/bin/sh
 
 # script/server: Launch the application and any extra required processes
-#                locally.
+#                locally. Use variables to control how you want to provision
+#                your local environment.
+#                Eg. `DOCKER=true script/console`
+#                Or, add this as a global variable to your shell so it's set
+#                automatically.
 
 set -e
 
+# Enable the running of this script from any subdirectory without moving to root
 cd "$(dirname "$0")/.."
 
-echo "==> Updating..."
-script/update
-
-echo "==> Starting the development server..."
-bundle exec rails server
+if [ "$CI" ]; then
+  echo "==> Running as CI..."
+  script/ci/server
+elif [ "$DOCKER" ]; then
+  echo "==> Running with Docker..."
+  script/docker/server
+else
+  echo "==> Running natively (no docker)..."
+  script/no-docker/server
+fi

--- a/script/setup
+++ b/script/setup
@@ -5,61 +5,18 @@
 
 set -e
 
+# Enable the running of this script from any subdirectory without moving to root
 cd "$(dirname "$0")/.."
-
-if [ -d vendor/bundle ]; then
-  echo "==> Cleaning installed Ruby dependencies..."
-  git clean -x --force -- vendor/bundle
-fi
-
-echo "==> Bootstrapping..."
-script/bootstrap
 
 if [ ! -f .env.development.local ]; then
   echo "==> Copying default environment config..."
   cp .env.example .env.development.local
 fi
 
-echo "==> Dropping database..."
-set +e
-bundle exec rails db:drop
-DB_DROP_RESULT=$?
-set -e
-
-if [ -z "$CI" ] && [ -n "$DB_DROP_RESULT" ]; then
-  printf "\\nDatabase drop failed. Continue anyway? [y/N] "
-  read -r
-
-  case $REPLY in
-    y | Y)
-      ;;
-    *)
-      exit 1
-      ;;
-  esac
+if [ "$DOCKER" ]; then
+  echo "==> Setting up with Docker..."
+  script/docker/setup "$@"
+else
+  echo "==> Settting up natively (no docker)..."
+  script/no-docker/setup "$@"
 fi
-
-echo "==> Creating database..."
-bundle exec rails db:setup
-
-echo "==> Dropping test database..."
-set +e
-RAILS_ENV="test" bundle exec rails db:drop
-DB_DROP_RESULT=$?
-set -e
-
-if [ -z "$CI" ] && [ -n "$DB_DROP_RESULT" ]; then
-  printf "\\nDatabase drop failed. Continue anyway? [y/N] "
-  read -r
-
-  case $REPLY in
-    y | Y)
-      ;;
-    *)
-      exit 1
-      ;;
-  esac
-fi
-
-echo "==> Creating test database..."
-RAILS_ENV="test" bundle exec rails db:setup

--- a/script/setup
+++ b/script/setup
@@ -8,12 +8,27 @@ set -e
 # Enable the running of this script from any subdirectory without moving to root
 cd "$(dirname "$0")/.."
 
+echo "==> Loading command line options…"
+DOCKER=${PREFER_DOCKER_FOR_DXW_RAILS:-0}
+for arg in "$@"
+do
+  case $arg in
+    --docker)
+      DOCKER=1
+      ;;
+    --no-docker)
+      DOCKER=0
+      ;;
+  esac
+  shift
+done
+
 if [ ! -f .env.development.local ]; then
   echo "==> Copying default environment config..."
   cp .env.example .env.development.local
 fi
 
-if [ "$DOCKER" ]; then
+if [ "$DOCKER" -eq 1 ]; then
   echo "==> Setting up with Docker..."
   script/docker/setup "$@"
 else

--- a/script/test
+++ b/script/test
@@ -1,55 +1,28 @@
 #!/bin/sh
 
-# script/test: Run the test suite for the application. Optionally pass in a path
-#              to an individual test file to run a single test.
+# script/test: Run the test suite for the application.
+#
+#              Optionally pass in a path to an individual test file to run a
+#              single test.
+#
+#              Use variables to control how you want to provision your local
+#              environment.
+#              Eg. `DOCKER=true script/console`
+#              Or, add this as a global variable to your shell so it's set
+#              automatically.
 
 set -e
 
+# Enable the running of this script from any subdirectory without moving to root
 cd "$(dirname "$0")/.."
 
-if [ -n "$DEBUG" ]; then
-  set -x
-fi
-
-echo "==> Updating..."
-script/update
-
-TEST_FILE=$1
-
-if [ -n "$TEST_FILE" ]; then
-  echo "==> Running the tests matching '$TEST_FILE'..."
-  bundle exec rspec --pattern "$TEST_FILE"
+if [ "$CI" ]; then
+  echo "==> Running as CI..."
+  script/ci/test "$@"
+elif [ "$DOCKER" ]; then
+  echo "==> Running with Docker..."
+  script/docker/test "$@"
 else
-  if [ -n "$CI" ]; then
-    echo "==> Checking formatting..."
-    yarn run lint:format
-  else
-    echo "==> Formatting files..."
-    yarn run lint:format:fix
-  fi
-
-  echo "==> Running ShellCheck..."
-  shellcheck script/*
-
-  if [ -n "$CI" ]; then
-    echo "==> Linting Ruby..."
-    bundle exec standardrb
-  else
-    echo "==> Linting Ruby in fix mode..."
-    bundle exec standardrb --fix
-  fi
-
-  if [ -n "$CI" ]; then
-    echo "==> Linting JS..."
-    yarn run lint:js
-  else
-    echo "==> Linting JS in fix mode..."
-    yarn run lint:js:fix
-  fi
-
-  echo "==> Running the tests..."
-  bundle exec rspec
-
-  echo "==> Running Brakeman"
-  bundle exec brakeman -o /dev/stdout
+  echo "==> Running natively (no docker)..."
+  script/no-docker/test "$@"
 fi

--- a/script/test
+++ b/script/test
@@ -49,4 +49,7 @@ else
 
   echo "==> Running the tests..."
   bundle exec rspec
+
+  echo "==> Running Brakeman"
+  bundle exec brakeman -o /dev/stdout
 fi

--- a/script/test
+++ b/script/test
@@ -16,10 +16,25 @@ set -e
 # Enable the running of this script from any subdirectory without moving to root
 cd "$(dirname "$0")/.."
 
+echo "==> Loading command line options…"
+DOCKER=${PREFER_DOCKER_FOR_DXW_RAILS:-0}
+for arg in "$@"
+do
+  case $arg in
+    --docker)
+      DOCKER=1
+      ;;
+    --no-docker)
+      DOCKER=0
+      ;;
+  esac
+  shift
+done
+
 if [ "$CI" ]; then
   echo "==> Running as CI..."
   script/ci/test "$@"
-elif [ "$DOCKER" ]; then
+elif [ "$DOCKER" -eq 1 ]; then
   echo "==> Running with Docker..."
   script/docker/test "$@"
 else

--- a/script/update
+++ b/script/update
@@ -7,7 +7,22 @@ set -e
 # Enable the running of this script from any subdirectory without moving to root
 cd "$(dirname "$0")/.."
 
-if [ "$DOCKER" ]; then
+echo "==> Loading command line options…"
+DOCKER=${PREFER_DOCKER_FOR_DXW_RAILS:-0}
+for arg in "$@"
+do
+  case $arg in
+    --docker)
+      DOCKER=1
+      ;;
+    --no-docker)
+      DOCKER=0
+      ;;
+  esac
+  shift
+done
+
+if [ "$DOCKER" -eq 1 ]; then
   echo "==> Running with Docker..."
   script/docker/update "$@"
 else

--- a/script/update
+++ b/script/update
@@ -4,13 +4,13 @@
 
 set -e
 
+# Enable the running of this script from any subdirectory without moving to root
 cd "$(dirname "$0")/.."
 
-echo "==> Bootstrapping..."
-script/bootstrap
-
-echo "==> Running database migrations..."
-bundle exec rails db:migrate
-
-echo "==> Running test database migrations..."
-RAILS_ENV="test" bundle exec rails db:migrate
+if [ "$DOCKER" ]; then
+  echo "==> Running with Docker..."
+  script/docker/update "$@"
+else
+  echo "==> Running natively (no docker)..."
+  script/no-docker/update "$@"
+fi


### PR DESCRIPTION
<!-- Do you need to update the changelog? -->

This change allows developers to run the application locally using Docker if they wish, by introducing Docker Compose. This is at least my preference for working with apps locally and I've found it to be generally viable as part of day-to-day dev.

We have existing scripts and documentation for starting applications _without_ Docker. These remain the same and honour the existing Scripts to Rule Them All pattern.

Using Docker in development has advantages of stronger parity. Given [we MUST always use containers to run CI and SHOULD used in live environments](https://github.com/dxw/tech-team-rfcs/blob/main/rfc-013-use-docker-to-deploy-and-run-applications-in-containers.md) using Docker locally can help identify environment shaped bugs earlier in delivery. Containerisation also rules out a whole category of issues related to our local environment, package versions etc. The script/bootstrap does attempt to deal with this but it cannot guarantee a fully compatible environment. 

Docker should always be stable given we use it for CI and live environments. Given we have the Docker work, by adding Docker compose we can leverage it for development and simpler getting started instructions (if you just want to have a play around).

## Changes in this PR

- Docker Compose support added
- CI uses Docker Compose rather than native Docker for stronger parity to development
- CI continues to use docker image caching 
- Following a change in organisation to the script directory we can now run the same scripts with Docker and as CI using variables such as `DOCKER=true` or `CI=true`
- For those that are working on the app and need to test regularly we continue to recommend testing outside of Docker. These changes only help us spin up a working server or exec onto a rails console (though a docker testing command is included)
- "Getting started" documentation moved to a standalone file to keep the README tidy and to help view a sum of the getting started options we now offer for comparison
- [We add Brakeman as part of our test suite](https://github.com/dxw/tech-team-rfcs/blob/main/rfc-024-use-brakeman.md) (this change is piggybacking on this PR and can be taken out if it becomes a problem)

## Screenshots of UI changes

Here we can see CI running with [our caching work](https://github.com/dxw/rails-template/pull/147) still in full effect (without caching this build takes ~5-7 minutes).

![Screenshot 2021-04-23 at 13 12 30](https://user-images.githubusercontent.com/912473/115871820-f3c79800-a438-11eb-8e16-dc94f57d266f.png)
