### PR TITLE
Dont send .git to the Docker Daemon

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -90,3 +90,5 @@
 /Brewfile
 ### Workflow configuration
 /.github/
+### git stuff
+/.git/


### PR DESCRIPTION
Containers rarely need the contents of `.git` to be present, so we shouldn't
send it by default to the docker daemon. In some cases `.git` can be quite
large so if sent will slow down the building of containers.
