### PR TITLE
Force SSL in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -48,7 +48,7 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.


### PR DESCRIPTION
## Changes in this PR

This does several things that make our app more secure by default[1]:

- Redirects any HTTP traffic to HTTPS (in production only)
- Enables HSTS headers which ensure user agents change HTTP into HTTPS before the request is made
- Marks cookies as secure so they are not sent over the wire in the clear

Though Rails starts with this commented out we should have a good reason for having these controls turned off.

I've seen multiple pen tests pick up on this missing setting.

[1] https://github.com/rails/rails/blob/794252d70990162d14da17ee854ad353e74297ee/actionpack/lib/action_dispatch/middleware/ssl.rb
