### PR TITLE
Enable Rails Content Security Policy

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -6,19 +6,19 @@
 # For further information see the following documentation
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
 
-# Rails.application.config.content_security_policy do |policy|
-#   policy.default_src :self, :https
-#   policy.font_src    :self, :https, :data
-#   policy.img_src     :self, :https, :data
-#   policy.object_src  :none
-#   policy.script_src  :self, :https
-#   policy.style_src   :self, :https
-#   # If you are using webpack-dev-server then specify webpack-dev-server host
-#   policy.connect_src :self, :https, "http://localhost:3035", "ws://localhost:3035" if Rails.env.development?
+Rails.application.config.content_security_policy do |policy|
+  policy.default_src :self, :https
+  policy.font_src :self, :https, :data
+  policy.img_src :self, :https, :data
+  policy.object_src :none
+  policy.script_src :self, :https
+  policy.style_src :self, :https
+  # If you are using webpack-dev-server then specify webpack-dev-server host
+  # policy.connect_src :self, :https, "http://localhost:3035", "ws://localhost:3035" if Rails.env.development?
 
-#   # Specify URI for violation reports
-#   # policy.report_uri "/csp-violation-report-endpoint"
-# end
+  # Specify URI for violation reports
+  # policy.report_uri "/csp-violation-report-endpoint"
+end
 
 # If you are using UJS then enable automatic nonce generation
 # Rails.application.config.content_security_policy_nonce_generator = -> request { SecureRandom.base64(16) }


### PR DESCRIPTION
We don't want scripts or images being loaded from external sites.

This is a defence in depth action. If user input is manipulated without being sanitised it could be allowed to make requests for external assets. For example, if the user  could inject a `<img src="evil.com">` into their (or another users) user-agent then they could use it to load/execute harmful scripts, hardware revealing information, improper images etc.

Turning this policy on tells user-agents not to try and load content from anywhere that's not the current domain(self) and HTTPS.

This omission is flagged by penetration tests.

Having this enabled should be our default standpoint for production. We should have a good reason for turning this setting off, which applications are still free to do. Additional trusted hosts can be added to this configuration as they become necessary.

https://guides.rubyonrails.org/security.html#content-security-policy
