### PR TITLE
Upgrade Rails configuration files with 6.1 defaults

### DIFF
--- a/bin/spring
+++ b/bin/spring
@@ -1,18 +1,16 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-# This file loads Spring without using Bundler, in order to be fast.
-# It gets overwritten when you run the `spring binstub` command.
+if !defined?(Spring) && [nil, "development", "test"].include?(ENV["RAILS_ENV"])
+  gem "bundler"
+  require "bundler"
 
-unless defined?(Spring)
-  require 'rubygems'
-  require 'bundler'
-
-  lockfile = Bundler::LockfileParser.new(Bundler.default_lockfile.read)
-  spring = lockfile.specs.detect { |spec| spec.name == 'spring' }
-  if spring
+  # Load Spring without loading other gems in the Gemfile, for speed.
+  Bundler.locked_gems&.specs&.find { |spec| spec.name == "spring" }&.tap do |spring|
     Gem.use_paths Gem.dir, Bundler.bundle_path.to_s, *Gem.path
-    gem 'spring', spring.version
-    require 'spring/binstub'
+    gem "spring", spring.version
+    require "spring/binstub"
+  rescue Gem::LoadError
+    # Ignore when Spring is not installed.
   end
 end

--- a/bin/yarn
+++ b/bin/yarn
@@ -3,9 +3,17 @@
 
 APP_ROOT = File.expand_path('..', __dir__)
 Dir.chdir(APP_ROOT) do
-  exec 'yarnpkg', *ARGV
-rescue Errno::ENOENT
-  warn 'Yarn executable was not detected in the system.'
-  warn 'Download Yarn at https://yarnpkg.com/en/docs/install'
-  exit 1
+  yarn = ENV["PATH"].split(File::PATH_SEPARATOR).
+    select { |dir| File.expand_path(dir) != __dir__ }.
+    product(["yarn", "yarn.cmd", "yarn.ps1"]).
+    map { |dir, file| File.expand_path(file, dir) }.
+    find { |file| File.executable?(file) }
+
+  if yarn
+    exec yarn, *ARGV
+  else
+    $stderr.puts "Yarn executable was not detected in the system."
+    $stderr.puts "Download Yarn at https://yarnpkg.com/en/docs/install"
+    exit 1
+  end
 end

--- a/config.ru
+++ b/config.ru
@@ -5,3 +5,4 @@
 require_relative "config/environment"
 
 run Rails.application
+Rails.application.load_server

--- a/config/application.rb
+++ b/config/application.rb
@@ -25,13 +25,16 @@ module RailsTemplate
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0
 
+    # Configuration for the application, engines, and railties goes here.
+    #
+    # These settings can be overridden in specific environments using the files
+    # in config/environments, which are processed later.
+    #
+    # config.time_zone = "Central Time (US & Canada)"
+    # config.eager_load_paths << Rails.root.join("extras")
+
     # Make sure the `form_with` helper generates local forms, instead of defaulting
     # to remote and unobtrusive XHR forms
     config.action_view.form_with_generates_remote_forms = false
-
-    # Settings in config/environments/* take precedence over those specified here.
-    # Application configuration can go into files in config/initializers
-    # -- all .rb files in that directory are automatically loaded after loading
-    # the framework and any gems in your application.
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -3,8 +3,8 @@
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
-  # In the development environment your application's code is reloaded on
-  # every request. This slows down response time but is perfect for development
+  # In the development environment your application's code is reloaded any time
+  # it changes. This slows down response time but is perfect for development
   # since you don't have to restart the web server when you make code changes.
   config.cache_classes = false
 
@@ -41,6 +41,12 @@ Rails.application.configure do
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
 
+  # Raise exceptions for disallowed deprecations.
+  config.active_support.disallowed_deprecation = :raise
+
+  # Tell Active Support which deprecation messages to disallow.
+  config.active_support.disallowed_deprecation_warnings = []
+
   # Raise an error on page load if there are pending migrations.
   config.active_record.migration_error = :page_load
 
@@ -55,8 +61,11 @@ Rails.application.configure do
   # Suppress logger output for asset requests.
   config.assets.quiet = true
 
-  # Raises error for missing translations
-  # config.action_view.raise_on_missing_translations = true
+  # Raises error for missing translations.
+  # config.i18n.raise_on_missing_translations = true
+
+  # Annotate rendered view with file names.
+  # config.action_view.annotate_rendered_view_with_filenames = true
 
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
@@ -64,4 +73,7 @@ Rails.application.configure do
 
   # Rails logging
   config.lograge.enabled = false
+
+  # Uncomment if you wish to allow Action Cable access from any origin.
+  # config.action_cable.disable_request_forgery_protection = true
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "active_support/core_ext/integer/time"
+
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
@@ -33,7 +35,7 @@ Rails.application.configure do
   config.assets.compile = false
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
-  # config.action_controller.asset_host = 'http://assets.example.com'
+  # config.asset_host = 'http://assets.example.com'
 
   # Specifies the header that your server uses for sending files.
   # config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache
@@ -50,9 +52,9 @@ Rails.application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = true
 
-  # Use the lowest log level to ensure availability of diagnostic information
-  # when problems arise.
-  config.log_level = :debug
+  # Include generic and useful information about system operation, but avoid logging too much
+  # information to avoid inadvertent exposure of personally identifiable information (PII).
+  config.log_level = :info
 
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]
@@ -76,6 +78,12 @@ Rails.application.configure do
 
   # Send deprecation notices to registered listeners.
   config.active_support.deprecation = :notify
+
+  # Log disallowed deprecations.
+  config.active_support.disallowed_deprecation = :log
+
+  # Tell Active Support which deprecation messages to disallow.
+  config.active_support.disallowed_deprecation_warnings = []
 
   # Use default logging formatter so that PID and timestamp are not suppressed.
   config.log_formatter = ::Logger::Formatter.new

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "active_support/core_ext/integer/time"
+
 # The test environment is used exclusively to run your application's
 # test suite. You never need to work with it otherwise. Remember that
 # your test database is "scratch space" for the test suite and is wiped
@@ -9,10 +11,6 @@ Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
   config.cache_classes = true
-
-  # Prevent 'reloading is disabled' errors from Spring
-  # https://github.com/rails/spring/issues/598
-  config.autoloader = :classic
 
   # Do not eager load code on boot. This avoids loading your whole application
   # just for the purpose of running a single test. If you are using a tool that
@@ -49,8 +47,17 @@ Rails.application.configure do
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
 
-  # Raises error for missing translations
-  # config.action_view.raise_on_missing_translations = true
+  # Raise exceptions for disallowed deprecations.
+  config.active_support.disallowed_deprecation = :raise
+
+  # Tell Active Support which deprecation messages to disallow.
+  config.active_support.disallowed_deprecation_warnings = []
+
+  # Raises error for missing translations.
+  # config.i18n.raise_on_missing_translations = true
+
+  # Annotate rendered view with file names.
+  # config.action_view.annotate_rendered_view_with_filenames = true
 
   # Set a css_compressor so sassc-rails does not overwrite the compressor when running the tests
   config.assets.css_compressor = nil

--- a/config/initializers/backtrace_silencers.rb
+++ b/config/initializers/backtrace_silencers.rb
@@ -3,7 +3,8 @@
 # Be sure to restart your server when you modify this file.
 
 # You can add backtrace silencers for libraries that you're using but don't wish to see in your backtraces.
-# Rails.backtrace_cleaner.add_silencer { |line| line =~ /my_noisy_library/ }
+# Rails.backtrace_cleaner.add_silencer { |line| /my_noisy_library/.match?(line) }
 
-# You can also remove all the silencers if you're trying to debug a problem that might stem from framework code.
-# Rails.backtrace_cleaner.remove_silencers!
+# You can also remove all the silencers if you're trying to debug a problem that might stem from framework code
+# by setting BACKTRACE=1 before calling your invocation, like "BACKTRACE=1 ./bin/rails runner 'MyClass.perform'".
+Rails.backtrace_cleaner.remove_silencers! if ENV["BACKTRACE"]

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -3,4 +3,6 @@
 # Be sure to restart your server when you modify this file.
 
 # Configure sensitive parameters which will be filtered from the log file.
-Rails.application.config.filter_parameters += [:password]
+Rails.application.config.filter_parameters += [
+  :password, :passw, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn
+]

--- a/config/initializers/new_framework_defaults_6_1.rb
+++ b/config/initializers/new_framework_defaults_6_1.rb
@@ -1,0 +1,67 @@
+# Be sure to restart your server when you modify this file.
+#
+# This file contains migration options to ease your Rails 6.1 upgrade.
+#
+# Once upgraded flip defaults one by one to migrate to the new default.
+#
+# Read the Guide for Upgrading Ruby on Rails for more info on each option.
+
+# Support for inversing belongs_to -> has_many Active Record associations.
+# Rails.application.config.active_record.has_many_inversing = true
+
+# Track Active Storage variants in the database.
+# Rails.application.config.active_storage.track_variants = true
+
+# Apply random variation to the delay when retrying failed jobs.
+# Rails.application.config.active_job.retry_jitter = 0.15
+
+# Stop executing `after_enqueue`/`after_perform` callbacks if
+# `before_enqueue`/`before_perform` respectively halts with `throw :abort`.
+# Rails.application.config.active_job.skip_after_callbacks_if_terminated = true
+
+# Specify cookies SameSite protection level: either :none, :lax, or :strict.
+#
+# This change is not backwards compatible with earlier Rails versions.
+# It's best enabled when your entire app is migrated and stable on 6.1.
+# Rails.application.config.action_dispatch.cookies_same_site_protection = :lax
+
+# Generate CSRF tokens that are encoded in URL-safe Base64.
+#
+# This change is not backwards compatible with earlier Rails versions.
+# It's best enabled when your entire app is migrated and stable on 6.1.
+# Rails.application.config.action_controller.urlsafe_csrf_tokens = true
+
+# Specify whether `ActiveSupport::TimeZone.utc_to_local` returns a time with an
+# UTC offset or a UTC time.
+# ActiveSupport.utc_to_local_returns_utc_offset_times = true
+
+# Change the default HTTP status code to `308` when redirecting non-GET/HEAD
+# requests to HTTPS in `ActionDispatch::SSL` middleware.
+# Rails.application.config.action_dispatch.ssl_default_redirect_status = 308
+
+# Use new connection handling API. For most applications this won't have any
+# effect. For applications using multiple databases, this new API provides
+# support for granular connection swapping.
+# Rails.application.config.active_record.legacy_connection_handling = false
+
+# Make `form_with` generate non-remote forms by default.
+# Rails.application.config.action_view.form_with_generates_remote_forms = false
+
+# Set the default queue name for the analysis job to the queue adapter default.
+# Rails.application.config.active_storage.queues.analysis = nil
+
+# Set the default queue name for the purge job to the queue adapter default.
+# Rails.application.config.active_storage.queues.purge = nil
+
+# Set the default queue name for the incineration job to the queue adapter default.
+# Rails.application.config.action_mailbox.queues.incineration = nil
+
+# Set the default queue name for the routing job to the queue adapter default.
+# Rails.application.config.action_mailbox.queues.routing = nil
+
+# Set the default queue name for the mail deliver job to the queue adapter default.
+# Rails.application.config.action_mailer.deliver_later_queue_name = nil
+
+# Generate a `Link` header that gives a hint to modern browsers about
+# preloading assets when using `javascript_include_tag` and `stylesheet_link_tag`.
+# Rails.application.config.action_view.preload_links_header = true

--- a/config/initializers/permissions_policy.rb
+++ b/config/initializers/permissions_policy.rb
@@ -1,0 +1,11 @@
+# Define an application-wide HTTP permissions policy. For further
+# information see https://developers.google.com/web/updates/2018/06/feature-policy
+#
+# Rails.application.config.permissions_policy do |f|
+#   f.camera      :none
+#   f.gyroscope   :none
+#   f.microphone  :none
+#   f.usb         :none
+#   f.fullscreen  :self
+#   f.payment     :self, "https://secure.example.com"
+# end

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -9,6 +9,11 @@
 threads_count = ENV.fetch("RAILS_MAX_THREADS", 5)
 threads threads_count, threads_count
 
+# Specifies the `worker_timeout` threshold that Puma will use to wait before
+# terminating a worker in development environments.
+#
+worker_timeout 3600 if ENV.fetch("RAILS_ENV", "development") == "development"
+
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 #
 port ENV.fetch("PORT", 3000)


### PR DESCRIPTION
Ensure that our configuration files are up to date with Rails 6.1 recommended defaults. This was done by running `rails app:update` and merging any changes we made.

NB: I've left the test environment running with the deprecated 'classic' autoloader rather than 'zeitwerk' because of
https://github.com/rails/spring/issues/598