### PR TITLE
Skip postgresql if it's already installed

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,5 +1,5 @@
 brew "nodenv"
-brew "postgresql"
+brew "postgresql" unless system "which -s psql"
 brew "rbenv"
 brew "shellcheck"
 brew "yarn"


### PR DESCRIPTION
As part of the `script/bootstrap` script, we install the `postgresql` package. If the developer has already installed `Postgres.app` (which has some [useful features](https://chrisrbailey.medium.com/postgres-on-mac-skip-brew-use-postgres-app-dda95da38d74)) they might run into issues.

So, let's amend the Brewfile to only install `postgresql` if the `psql` command isn't already available.