### PR TITLE
Expose the git SHA and the build time of the last build in `/healthcheck`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,17 @@ COPY . $INSTALL_PATH
 
 RUN RAILS_ENV=$RAILS_ENV SECRET_KEY_BASE="super secret" bundle exec rake assets:precompile --quiet
 
+# TODO:
+# In order to expose the current git sha & time of build in the /healthcheck
+# endpoint, pass these values into your deployment script, for example:
+# --build-arg current_sha="$GITHUB_SHA" \
+# --build-arg time_of_build="$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
+ARG current_sha
+ARG time_of_build
+
+ENV CURRENT_SHA=$current_sha
+ENV TIME_OF_BUILD=$time_of_build
+
 # db setup
 COPY ./docker-entrypoint.sh /
 RUN chmod +x /docker-entrypoint.sh

--- a/Gemfile
+++ b/Gemfile
@@ -48,4 +48,5 @@ group :test do
   gem "launchy"
   gem "selenium-webdriver"
   gem "simplecov"
+  gem "climate_control"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,6 +91,7 @@ GEM
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
     childprocess (3.0.0)
+    climate_control (1.0.1)
     coderay (1.1.3)
     coffee-rails (5.0.0)
       coffee-script (>= 2.2.0)
@@ -311,6 +312,7 @@ DEPENDENCIES
   bullet
   byebug
   capybara (>= 2.15)
+  climate_control
   coffee-rails (~> 5.0)
   database_cleaner
   dotenv-rails

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,10 @@
 
 class ApplicationController < ActionController::Base
   def health_check
-    render json: {rails: "OK"}, status: :ok
+    render json: {
+      rails: "OK",
+      git_sha: ENV.fetch("CURRENT_SHA", "UNKNOWN"),
+      built_at: ENV.fetch("TIME_OF_BUILD", "UNKNOWN")
+    }, status: :ok
   end
 end

--- a/spec/requests/health_check_spec.rb
+++ b/spec/requests/health_check_spec.rb
@@ -4,6 +4,31 @@ RSpec.describe "Health Check", type: :request do
   it "returns an ok HTTP status code without requiring authentication" do
     get "/health_check", headers: {"CONTENT_TYPE" => "application/json", "ACCEPT" => "application/json"}
     expect(response).to have_http_status(:ok)
-    expect(JSON.parse(response.body)).to eql("rails" => "OK")
+    expect(JSON.parse(response.body)).to include("rails" => "OK")
+  end
+
+  it "includes the git_sha if it is present" do
+    ClimateControl.modify CURRENT_SHA: "123-abc-456-def" do
+      get "/health_check", headers: {"CONTENT_TYPE" => "application/json", "ACCEPT" => "application/json"}
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body)).to include("git_sha" => "123-abc-456-def")
+    end
+  end
+
+  it "includes the built_at datetime if it is present" do
+    ClimateControl.modify TIME_OF_BUILD: Time.zone.today.strftime("%Y-%m-%dT%H:%M:%S") do
+      get "/health_check", headers: {"CONTENT_TYPE" => "application/json", "ACCEPT" => "application/json"}
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body)).to include("built_at" => Time.zone.today.strftime("%Y-%m-%dT%H:%M:%S"))
+    end
+  end
+
+  it "returns UNKNOWN if the git_sha and / or built_at are unset" do
+    ClimateControl.modify TIME_OF_BUILD: nil, CURRENT_SHA: nil do
+      get "/health_check", headers: {"CONTENT_TYPE" => "application/json", "ACCEPT" => "application/json"}
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body)).to include("built_at" => "UNKNOWN")
+      expect(JSON.parse(response.body)).to include("git_sha" => "UNKNOWN")
+    end
   end
 end


### PR DESCRIPTION

During a recent hackday, an idea was put forward to expose the git sha and
build time of a deployed application's current deployment. As a team, we worked
to expose these details in the `/healthcheck` endpoint of an existing
application. This work is replicated here in rails-template to make it a
part of our boilerplate application.

As rails-template does not include a build script, this piece is missing from
this commit. To populate these values, pass them as arguments when building
the docker image for deployment. For example:

```
docker build --target web \
  --build-arg current_sha="$GITHUB_SHA" \
  --build-arg time_of_build="$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
  -t "<where the image is to be deployed>:$DOCKER_TAG" \
  .
```

Assuming you are using Github actions to deploy, the sha is grabbable from
${GITHUB_SHA} in github actions.

To view a demo application consuming this data, see:
https://github.com/dxw/detect-a-deployment-hackday

Co-authored-by: lawrence-forooghian <lawrence@dxw.com>
Co-authored-by: pezholio <stuart@dxw.com>
Co-authored-by: leedxw <lee@dxw.com>

<!-- Do you need to update the changelog? -->

## Changes in this PR

## Screenshots of UI changes

### Before

### After

## Next steps
