### PR TITLE
Include accessibility reminder in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,3 +9,5 @@
 ### After
 
 ## Next steps
+
+- [ ] Run any necessary [accessibility testing](https://playbook.dxw.com/guides/web-accessibility.html) on this feature.


### PR DESCRIPTION
We should be considering accessibility in every change we make; this adds a reminder to make sure it's at least considered as part of creating a pull request.
