### PR TITLE
Rearrange tests so slow linting is last and tests are first

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,3 +2,4 @@
 /tmp/
 /vendor/
 /public/assets
+/coverage

--- a/.prettierignore
+++ b/.prettierignore
@@ -25,3 +25,4 @@
 *.txt
 *.gz
 /public/assets/*
+/coverage

--- a/script/test
+++ b/script/test
@@ -20,13 +20,8 @@ if [ -n "$TEST_FILE" ]; then
   echo "==> Running the tests matching '$TEST_FILE'..."
   bundle exec rspec --pattern "$TEST_FILE"
 else
-  if [ -n "$CI" ]; then
-    echo "==> Checking formatting..."
-    yarn run lint:format
-  else
-    echo "==> Formatting files..."
-    yarn run lint:format:fix
-  fi
+  echo "==> Running the tests..."
+  bundle exec rspec
 
   echo "==> Running ShellCheck..."
   shellcheck script/*
@@ -47,6 +42,11 @@ else
     yarn run lint:js:fix
   fi
 
-  echo "==> Running the tests..."
-  bundle exec rspec
+  if [ -n "$CI" ]; then
+    echo "==> Checking formatting..."
+    yarn run lint:format
+  else
+    echo "==> Formatting files..."
+    yarn run lint:format:fix
+  fi
 fi


### PR DESCRIPTION
## Changes in this PR
`yarn run lint:format:fix` takes a long time to run; we should ensure tests of functionality succeed or fail quickly so people can iterate rapidly.

We now also ignore the coverage directory as it takes around a minute to process it.

## Screenshots of UI changes
No UI changes.
