### PR TITLE
Workflow to monitor PR age

### DIFF
--- a/.github/actions/pull-requests.js
+++ b/.github/actions/pull-requests.js
@@ -1,0 +1,153 @@
+module.exports = {
+  async olderThan({ github, context }, { days }) {
+    const millisecondsAgo = Date.now() - days * 24 * 60 * 60 * 1000;
+
+    const {
+      repository: {
+        pullRequests: { nodes: allPullRequests },
+      },
+    } = await github.graphql(
+      `
+        query($owner: String!, $name: String!) {
+          repository(owner: $owner, name: $name) {
+            pullRequests(first: 100, states: [OPEN]) {
+              nodes {
+                id
+                createdAt
+                isDraft
+                timelineItems(
+                  itemTypes: [
+                    CLOSED_EVENT
+                    CONVERT_TO_DRAFT_EVENT
+                    READY_FOR_REVIEW_EVENT
+                    REOPENED_EVENT
+                  ]
+                  last: 100
+                ) {
+                  nodes {
+                    __typename
+                    ... on ClosedEvent {
+                      createdAt
+                    }
+                    ... on ConvertToDraftEvent {
+                      createdAt
+                    }
+                    ... on ReadyForReviewEvent {
+                      createdAt
+                    }
+                    ... on ReopenedEvent {
+                      createdAt
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      `,
+      {
+        owner: context.repo.owner,
+        name: context.repo.repo,
+      }
+    );
+
+    console.log("Found %d open pull requests", allPullRequests.length);
+
+    const nonDraftPullRequests = allPullRequests.filter((pr) => !pr.isDraft);
+
+    console.log(
+      "Found %d non-draft pull requests",
+      nonDraftPullRequests.length
+    );
+
+    const pullRequestsReadyForReviewBeforeCutoff = nonDraftPullRequests.filter(
+      (pr) => {
+        if (pr.timelineItems.nodes.length === 0) {
+          return new Date(pr.createdAt).valueOf() < millisecondsAgo;
+        }
+
+        const events = pr.timelineItems.nodes
+          .map((event) => ({
+            ...event,
+            createdAt: new Date(event.createdAt).valueOf(),
+          }))
+          .sort((a, b) => b.createdAt - a.createdAt);
+
+        const latestEvent = events[0];
+
+        if (
+          ["ClosedEvent", "ConvertToDraftEvent"].includes(
+            latestEvent.__typename
+          )
+        ) {
+          return false;
+        }
+
+        return latestEvent.createdAt < millisecondsAgo;
+      }
+    );
+
+    console.log(
+      "Found %d pull requests last made ready for review %d days or longer ago",
+      pullRequestsReadyForReviewBeforeCutoff.length,
+      days
+    );
+
+    const pullRequestIds = pullRequestsReadyForReviewBeforeCutoff.map(
+      (pr) => pr.id
+    );
+
+    return pullRequestIds;
+  },
+
+  async removeLabelFrom({ github, context }, { ids, labelName }) {
+    if (ids.length === 0) {
+      return;
+    }
+
+    const {
+      repository: { label },
+    } = await github.graphql(
+      `
+        query($owner: String!, $name: String!, $labelName: String!) {
+          repository(owner: $owner, name: $name) {
+            label(name: $labelName) {
+              id
+            }
+          }
+        }
+      `,
+      {
+        owner: context.repo.owner,
+        name: context.repo.repo,
+        labelName,
+      }
+    );
+
+    if (!label) {
+      throw new Error(`Unable to find label with name: ${labelName}`);
+    }
+
+    await Promise.all(
+      ids.map((id) =>
+        github.graphql(
+          `
+            mutation($input: RemoveLabelsFromLabelableInput!) {
+              removeLabelsFromLabelable(input: $input) {
+                clientMutationId
+              }
+            }
+          `,
+          {
+            input: {
+              labelIds: [label.id],
+              labelableId: id,
+            },
+          }
+        )
+      )
+    );
+
+    return;
+  },
+};

--- a/.github/workflows/automatic-rebase.yml
+++ b/.github/workflows/automatic-rebase.yml
@@ -1,4 +1,3 @@
-name: Automatic Rebase
 on:
   issue_comment:
     types:
@@ -12,7 +11,7 @@ env:
     ${{ secrets.AUTO_REBASE_PERSONAL_ACCESS_TOKEN }}
 
 jobs:
-  check_token:
+  check-token:
     if: |
       (
         github.event.issue.pull_request &&
@@ -42,7 +41,7 @@ jobs:
             ${{ env.AUTO_REBASE_PERSONAL_ACCESS_TOKEN && '+1' || '-1' }}
 
   rebase:
-    needs: check_token
+    needs: check-token
     if: |
       (
         (
@@ -83,4 +82,4 @@ jobs:
         uses: peter-evans/create-or-update-comment@v1
         with:
           comment-id: ${{ github.event.comment.id }}
-          reactions: Hooray
+          reactions: hooray

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,7 +1,5 @@
 # TODO: Enable GitHub Actions on the repository to test all pull requests
 # https://github.com/<org>/<repo>/actions
-name: CI
-
 on:
   pull_request:
   push:
@@ -12,11 +10,14 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+
     env:
       RAILS_ENV: test
+
     steps:
       - name: Check out code
         uses: actions/checkout@v2
+
       - id: cache-docker
         uses: actions/cache@v2
         with:
@@ -24,15 +25,19 @@ jobs:
           key:
             docker-save-${{ hashFiles('Dockerfile', 'Gemfile.lock',
             'package-lock.json') }}
-      - name: Load cached Docker image
+
+      - if: steps.cache-docker.outputs.cache-hit == 'true'
+        name: Load cached Docker image
         run: docker load -i /tmp/docker-save/snapshot.tar || true
-        if: steps.cache-docker.outputs.cache-hit == 'true'
+
       - name: Build
         run: script/ci/cibuild
+
       - name: Test
         run: script/ci/test
-      - name: Prepare Docker cache
+
+      - if: always() && steps.cache-docker.outputs.cache-hit != 'true'
+        name: Prepare Docker cache
         run:
           mkdir -p /tmp/docker-save && docker save app_test:latest -o
           /tmp/docker-save/snapshot.tar && ls -lh /tmp/docker-save
-        if: always() && steps.cache-docker.outputs.cache-hit != 'true'

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -77,3 +77,10 @@ jobs:
             Automatic rebasing for this issue has failed :disappointed:
 
             You'll have to rebase this one manually, I'm afraid.
+
+      - if: success() && github.event.comment
+        name: React to the triggering comment
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          comment-id: ${{ github.event.comment.id }}
+          reactions: Hooray

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -1,67 +1,75 @@
 name: Automatic Rebase
 on:
   issue_comment:
-    types: [created]
+    types:
+      - created
   pull_request_target:
-    types: [auto_merge_enabled]
+    types:
+      - auto_merge_enabled
+
 env:
   AUTO_REBASE_PERSONAL_ACCESS_TOKEN:
     ${{ secrets.AUTO_REBASE_PERSONAL_ACCESS_TOKEN }}
+
 jobs:
   check_token:
-    if:
-      ${{ (github.event.issue.pull_request != '' &&
-      contains(github.event.comment.body, '/rebase')) || github.event_name ==
-      'pull_request_target' }}
+    if: |
+      (
+        github.event.issue.pull_request &&
+        contains(github.event.comment.body, '/rebase')
+      ) ||
+      github.event_name == 'pull_request_target'
+
     runs-on: ubuntu-latest
+
     steps:
-      - name: Prompt user to add a token
+      - if: "! env.AUTO_REBASE_PERSONAL_ACCESS_TOKEN"
+        name: Prompt to add a token
         uses: peter-evans/create-or-update-comment@v1
         with:
           issue-number: ${{ github.event.issue.number || github.event.number }}
           body: |
-            To automatically rebase, you need to add a [personal access token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) with the name `AUTO_REBASE_PERSONAL_ACCESS_TOKEN`
-            to the [secrets section of this repo](https://github.com/${{ github.event.repository.full_name }}/settings/secrets/actions).
+            To automatically rebase, you need to add a [personal access token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) with the name `AUTO_REBASE_PERSONAL_ACCESS_TOKEN` to the [secrets section of this repo](https://github.com/${{ github.event.repository.full_name }}/settings/secrets/actions).
 
             Once this is done, you can try the `/rebase` command again.
-        if: ${{ env.AUTO_REBASE_PERSONAL_ACCESS_TOKEN == '' }}
-      - name: Add -1 reaction
+
+      - if: github.event.comment
+        name: React to the triggering comment
         uses: peter-evans/create-or-update-comment@v1
         with:
           comment-id: ${{ github.event.comment.id }}
-          reactions: "-1"
-        if:
-          ${{ env.AUTO_REBASE_PERSONAL_ACCESS_TOKEN == '' &&
-          github.event.comment }}
-      - name: Add +1 reaction
-        uses: peter-evans/create-or-update-comment@v1
-        with:
-          comment-id: ${{ github.event.comment.id }}
-          reactions: "+1"
-        if:
-          ${{ env.AUTO_REBASE_PERSONAL_ACCESS_TOKEN != '' &&
-          github.event.comment }}
+          reactions:
+            ${{ env.AUTO_REBASE_PERSONAL_ACCESS_TOKEN && '+1' || '-1' }}
+
   rebase:
-    if:
-      ${{ github.event.issue.pull_request != '' &&
-      contains(github.event.comment.body, '/rebase') || github.event_name ==
-      'pull_request_target' }}
-    name: Rebase
     needs: check_token
+    if: |
+      (
+        (
+          github.event.issue.pull_request &&
+          contains(github.event.comment.body, '/rebase')
+        ) ||
+        github.event_name == 'pull_request_target'
+      ) &&
+      env.AUTO_REBASE_PERSONAL_ACCESS_TOKEN
+
+    name: Rebase
+
     runs-on: ubuntu-latest
+
     steps:
-      - name: Checkout the latest code
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v2
         with:
           token: ${{ env.AUTO_REBASE_PERSONAL_ACCESS_TOKEN }}
           fetch-depth: 0
-        if: ${{ env.AUTO_REBASE_PERSONAL_ACCESS_TOKEN != '' }}
-      - name: Automatic Rebase
+
+      - name: Rebase on top of the default branch
         uses: cirrus-actions/rebase@1.4
         env:
           GITHUB_TOKEN: ${{ env.AUTO_REBASE_PERSONAL_ACCESS_TOKEN }}
-        if: ${{ env.AUTO_REBASE_PERSONAL_ACCESS_TOKEN != '' }}
-      - name: Send failure message
+
+      - if: failure()
+        name: Notify of the failure
         uses: peter-evans/create-or-update-comment@v1
         with:
           issue-number: ${{ github.event.issue.number || github.event.number }}
@@ -69,4 +77,3 @@ jobs:
             Automatic rebasing for this issue has failed :disappointed:
 
             You'll have to rebase this one manually, I'm afraid.
-        if: ${{ failure() }}

--- a/.github/workflows/review-requirements/check-labels.yml
+++ b/.github/workflows/review-requirements/check-labels.yml
@@ -5,13 +5,13 @@ on:
       - unlabeled
 
 jobs:
-  check-for-too-new-to-merge:
+  check-for-new:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Check if labelled as "too-new-to-merge"
+      - name: Check if labelled as "new"
         run: |
-          if [ "${{ contains(github.event.pull_request.labels.*.name, 'too-new-to-merge') }}" = true ]; then
+          if [ "${{ contains(github.event.pull_request.labels.*.name, 'new') }}" = true ]; then
             echo "::error::This PR is still too new to merge"
             exit 1
           fi

--- a/.github/workflows/review-requirements/check-labels.yml
+++ b/.github/workflows/review-requirements/check-labels.yml
@@ -1,0 +1,17 @@
+on:
+  pull_request:
+    types:
+      - labeled
+      - unlabeled
+
+jobs:
+  check-for-too-new-to-merge:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check if labelled as "too-new-to-merge"
+        run: |
+          if [ "${{ contains(github.event.pull_request.labels.*.name, 'too-new-to-merge') }}" = true ]; then
+            echo "::error::This PR is still too new to merge"
+            exit 1
+          fi

--- a/.github/workflows/review-requirements/label-pull-request.yml
+++ b/.github/workflows/review-requirements/label-pull-request.yml
@@ -1,0 +1,18 @@
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - ready_for_review
+
+jobs:
+  label-as-too-new-to-merge:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Label as "too-new-to-merge"
+        uses: andymckay/labeler@1.0.3
+        with:
+          add-labels: "too-new-to-merge"
+          ignore-if-assigned: false
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/review-requirements/label-pull-request.yml
+++ b/.github/workflows/review-requirements/label-pull-request.yml
@@ -6,13 +6,13 @@ on:
       - ready_for_review
 
 jobs:
-  label-as-too-new-to-merge:
+  label-as-new:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Label as "too-new-to-merge"
+      - name: Label as "new"
         uses: andymckay/labeler@1.0.3
         with:
-          add-labels: "too-new-to-merge"
+          add-labels: "new"
           ignore-if-assigned: false
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/review-requirements/update-all-prs.yml
+++ b/.github/workflows/review-requirements/update-all-prs.yml
@@ -1,0 +1,39 @@
+on:
+  schedule:
+    # Every 10 minutes
+    cron: "*/10 * * * *"
+  workflow_dispatch:
+
+jobs:
+  unlabel-prs-as-too-new-to-merge:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - id: select-pull-requests
+        name: Select PRs older than 14 days
+        uses: actions/github-script@v5.0.0
+        with:
+          script: |
+            const pullRequests = require("./.github/actions/pull-requests");
+
+            return pullRequests.olderThan(
+              { github, context },
+              { days: 14 },
+            );
+
+      - if: steps.select-pull-requests.outputs.result
+        name: Unlabel old enough PRs as "too-new-to-merge"
+        uses: actions/github-script@v5.0.0
+        with:
+          script: |
+            const pullRequests = require("./.github/actions/pull-requests");
+
+            return pullRequests.removeLabelFrom(
+              { github, context },
+              {
+                ids: ${{ steps.select-pull-requests.outputs.result }},
+                labelName: "too-new-to-merge",
+              },
+            );

--- a/.github/workflows/review-requirements/update-all-prs.yml
+++ b/.github/workflows/review-requirements/update-all-prs.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  unlabel-prs-as-too-new-to-merge:
+  unlabel-prs-as-new:
     runs-on: ubuntu-latest
 
     steps:
@@ -24,7 +24,7 @@ jobs:
             );
 
       - if: steps.select-pull-requests.outputs.result
-        name: Unlabel old enough PRs as "too-new-to-merge"
+        name: Unlabel old enough PRs as "new"
         uses: actions/github-script@v5.0.0
         with:
           script: |
@@ -34,6 +34,6 @@ jobs:
               { github, context },
               {
                 ids: ${{ steps.select-pull-requests.outputs.result }},
-                labelName: "too-new-to-merge",
+                labelName: "new",
               },
             );


### PR DESCRIPTION
For fun on my time off, I was wondering what it would take to monitor PR age using GitHub Actions alone. This is what I came up with. Please feel free to tear the approach apart :)

## Changes in this PR

This PR introduces the workflow for requiring PRs to stay open for at least 14 days before merging. It uses 3 workflows to achieve this:

1. When a new PR is opened or a PR is reopened or marked as ready for review, we label it as "too-new-to-merge"
2. When a label changes on a PR, we check to see if it still has the "too-new-to-merge" label
3. Every 10 minutes (probably overkill), we check every PR to see if it's been reviewable for at least 14 days and remove the label if appropriate

Step 3 uses [GitHub's GraphQL API](https://docs.github.com/en/graphql), which took a little to get my head around.

This PR also performs some simplification of and readability improvements for other workflows. I'm very happy to pull those out into their own PR if they're contentious.