### PR TITLE
Fail tests hard

### DIFF
--- a/script/docker/test
+++ b/script/docker/test
@@ -9,4 +9,4 @@ cd "$(dirname "$0")/../.."
 
 docker-compose -f docker-compose.test.yml \
                run --rm test \
-               script/run_all_tests "$@"
+               script/test_wrapper "$@"

--- a/script/no-docker/test
+++ b/script/no-docker/test
@@ -15,4 +15,4 @@ fi
 echo "==> Updating..."
 script/no-docker/update
 
-AUTOMATICALLY_FIX_LINTING=true script/run_all_tests "$@"
+AUTOMATICALLY_FIX_LINTING=true script/test_wrapper "$@"

--- a/script/run_all_tests
+++ b/script/run_all_tests
@@ -1,5 +1,5 @@
 #!/bin/sh
-
+set -e
 # Run the test suite for the application. Optionally pass in a path to an
 # individual test file to run a single test.
 
@@ -45,3 +45,5 @@ else
   echo "==> Running Brakeman..."
   bundle exec brakeman -o /dev/stdout
 fi
+
+echo "All linters and tests passed."

--- a/script/test_wrapper
+++ b/script/test_wrapper
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+if script/run_all_tests "$@"; then
+  echo -e "\033[42m\033[30m     Tests passed! :)     \033[0m"
+  exit 0
+else
+  echo -e "\033[101m\033[30m     Tests did not pass     \033[0m"
+  exit 1
+fi


### PR DESCRIPTION
scripts/run_all_tests didn't use `set -e` or similar, so it'd never fail even if individual tests were failing.

Getting this working locally will depend on a number of other pull requests being accepted, notably shellcheck and linted docs.

Additionally, there's a number of major problems with the test suite execution in CI, so tests are going to fail on this until that's resolved. 

I chose not to use test_wrapper for the CI but am ambivalent about that decision.

```
$ prettier --write '**/*' 
/bin/sh: 1: prettier: not found 
error Command failed with exit code 127.

==> Running ShellCheck... 
fatal: not a git repository (or any of the parent directories): .git

  $ eslint . —fix 
/bin/sh: 1: eslint: not found 
error Command failed with exit code 127. 
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command. 
error Command failed with exit code 127.
```