### PR TITLE
Clean up the workflows

### DIFF
--- a/.github/workflows/automatic-rebase.yml
+++ b/.github/workflows/automatic-rebase.yml
@@ -1,4 +1,3 @@
-name: Automatic Rebase
 on:
   issue_comment:
     types:
@@ -12,7 +11,7 @@ env:
     ${{ secrets.AUTO_REBASE_PERSONAL_ACCESS_TOKEN }}
 
 jobs:
-  check_token:
+  check-token:
     if: |
       (
         github.event.issue.pull_request &&
@@ -42,7 +41,7 @@ jobs:
             ${{ env.AUTO_REBASE_PERSONAL_ACCESS_TOKEN && '+1' || '-1' }}
 
   rebase:
-    needs: check_token
+    needs: check-token
     if: |
       (
         (
@@ -83,4 +82,4 @@ jobs:
         uses: peter-evans/create-or-update-comment@v1
         with:
           comment-id: ${{ github.event.comment.id }}
-          reactions: Hooray
+          reactions: hooray

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,7 +1,5 @@
 # TODO: Enable GitHub Actions on the repository to test all pull requests
 # https://github.com/<org>/<repo>/actions
-name: CI
-
 on:
   pull_request:
   push:
@@ -12,11 +10,14 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+
     env:
       RAILS_ENV: test
+
     steps:
       - name: Check out code
         uses: actions/checkout@v2
+
       - id: cache-docker
         uses: actions/cache@v2
         with:
@@ -24,15 +25,19 @@ jobs:
           key:
             docker-save-${{ hashFiles('Dockerfile', 'Gemfile.lock',
             'package-lock.json') }}
-      - name: Load cached Docker image
+
+      - if: steps.cache-docker.outputs.cache-hit == 'true'
+        name: Load cached Docker image
         run: docker load -i /tmp/docker-save/snapshot.tar || true
-        if: steps.cache-docker.outputs.cache-hit == 'true'
+
       - name: Build
         run: script/ci/cibuild
+
       - name: Test
         run: script/ci/test
-      - name: Prepare Docker cache
+
+      - if: always() && steps.cache-docker.outputs.cache-hit != 'true'
+        name: Prepare Docker cache
         run:
           mkdir -p /tmp/docker-save && docker save app_test:latest -o
           /tmp/docker-save/snapshot.tar && ls -lh /tmp/docker-save
-        if: always() && steps.cache-docker.outputs.cache-hit != 'true'

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -77,3 +77,10 @@ jobs:
             Automatic rebasing for this issue has failed :disappointed:
 
             You'll have to rebase this one manually, I'm afraid.
+
+      - if: success() && github.event.comment
+        name: React to the triggering comment
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          comment-id: ${{ github.event.comment.id }}
+          reactions: Hooray

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -1,67 +1,75 @@
 name: Automatic Rebase
 on:
   issue_comment:
-    types: [created]
+    types:
+      - created
   pull_request_target:
-    types: [auto_merge_enabled]
+    types:
+      - auto_merge_enabled
+
 env:
   AUTO_REBASE_PERSONAL_ACCESS_TOKEN:
     ${{ secrets.AUTO_REBASE_PERSONAL_ACCESS_TOKEN }}
+
 jobs:
   check_token:
-    if:
-      ${{ (github.event.issue.pull_request != '' &&
-      contains(github.event.comment.body, '/rebase')) || github.event_name ==
-      'pull_request_target' }}
+    if: |
+      (
+        github.event.issue.pull_request &&
+        contains(github.event.comment.body, '/rebase')
+      ) ||
+      github.event_name == 'pull_request_target'
+
     runs-on: ubuntu-latest
+
     steps:
-      - name: Prompt user to add a token
+      - if: "! env.AUTO_REBASE_PERSONAL_ACCESS_TOKEN"
+        name: Prompt to add a token
         uses: peter-evans/create-or-update-comment@v1
         with:
           issue-number: ${{ github.event.issue.number || github.event.number }}
           body: |
-            To automatically rebase, you need to add a [personal access token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) with the name `AUTO_REBASE_PERSONAL_ACCESS_TOKEN`
-            to the [secrets section of this repo](https://github.com/${{ github.event.repository.full_name }}/settings/secrets/actions).
+            To automatically rebase, you need to add a [personal access token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) with the name `AUTO_REBASE_PERSONAL_ACCESS_TOKEN` to the [secrets section of this repo](https://github.com/${{ github.event.repository.full_name }}/settings/secrets/actions).
 
             Once this is done, you can try the `/rebase` command again.
-        if: ${{ env.AUTO_REBASE_PERSONAL_ACCESS_TOKEN == '' }}
-      - name: Add -1 reaction
+
+      - if: github.event.comment
+        name: React to the triggering comment
         uses: peter-evans/create-or-update-comment@v1
         with:
           comment-id: ${{ github.event.comment.id }}
-          reactions: "-1"
-        if:
-          ${{ env.AUTO_REBASE_PERSONAL_ACCESS_TOKEN == '' &&
-          github.event.comment }}
-      - name: Add +1 reaction
-        uses: peter-evans/create-or-update-comment@v1
-        with:
-          comment-id: ${{ github.event.comment.id }}
-          reactions: "+1"
-        if:
-          ${{ env.AUTO_REBASE_PERSONAL_ACCESS_TOKEN != '' &&
-          github.event.comment }}
+          reactions:
+            ${{ env.AUTO_REBASE_PERSONAL_ACCESS_TOKEN && '+1' || '-1' }}
+
   rebase:
-    if:
-      ${{ github.event.issue.pull_request != '' &&
-      contains(github.event.comment.body, '/rebase') || github.event_name ==
-      'pull_request_target' }}
-    name: Rebase
     needs: check_token
+    if: |
+      (
+        (
+          github.event.issue.pull_request &&
+          contains(github.event.comment.body, '/rebase')
+        ) ||
+        github.event_name == 'pull_request_target'
+      ) &&
+      env.AUTO_REBASE_PERSONAL_ACCESS_TOKEN
+
+    name: Rebase
+
     runs-on: ubuntu-latest
+
     steps:
-      - name: Checkout the latest code
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v2
         with:
           token: ${{ env.AUTO_REBASE_PERSONAL_ACCESS_TOKEN }}
           fetch-depth: 0
-        if: ${{ env.AUTO_REBASE_PERSONAL_ACCESS_TOKEN != '' }}
-      - name: Automatic Rebase
+
+      - name: Rebase on top of the default branch
         uses: cirrus-actions/rebase@1.4
         env:
           GITHUB_TOKEN: ${{ env.AUTO_REBASE_PERSONAL_ACCESS_TOKEN }}
-        if: ${{ env.AUTO_REBASE_PERSONAL_ACCESS_TOKEN != '' }}
-      - name: Send failure message
+
+      - if: failure()
+        name: Notify of the failure
         uses: peter-evans/create-or-update-comment@v1
         with:
           issue-number: ${{ github.event.issue.number || github.event.number }}
@@ -69,4 +77,3 @@ jobs:
             Automatic rebasing for this issue has failed :disappointed:
 
             You'll have to rebase this one manually, I'm afraid.
-        if: ${{ failure() }}


### PR DESCRIPTION
Pulled out of #292, this PR makes some small improvements to the GitHub actions. Most of the changes are for readability, but it also adds a 🎉 on rebase requests that have been processed.

Note that the workflow and job name changes will require updating the branch protection rules.