### PR TITLE
Revert "Remove CoffeeScript"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ ruby "2.7.2"
 
 gem "bootsnap", ">= 1.1.0", require: false
 gem "bootstrap", ">= 4.3.1"
+gem "coffee-rails", "~> 5.0"
 gem "high_voltage"
 gem "jbuilder", "~> 2.11"
 gem "jquery-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,6 +93,13 @@ GEM
     childprocess (3.0.0)
     climate_control (1.0.1)
     coderay (1.1.3)
+    coffee-rails (5.0.0)
+      coffee-script (>= 2.2.0)
+      railties (>= 5.2.0)
+    coffee-script (2.4.1)
+      coffee-script-source
+      execjs
+    coffee-script-source (1.12.2)
     concurrent-ruby (1.1.9)
     crass (1.0.6)
     database_cleaner (2.0.1)
@@ -313,6 +320,7 @@ DEPENDENCIES
   byebug
   capybara (>= 2.15)
   climate_control
+  coffee-rails (~> 5.0)
   database_cleaner
   dotenv-rails
   factory_bot_rails

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,7 +1,7 @@
 // This is a manifest file that'll be compiled into application.js, which will include all the files
 // listed below.
 //
-// Any JavaScript file within this directory, lib/assets/javascripts, or any plugin's
+// Any JavaScript/Coffee file within this directory, lib/assets/javascripts, or any plugin's
 // vendor/assets/javascripts directory can be referenced here using a relative path.
 //
 // It's not advisable to add code directly here, but if you do, it'll appear at the bottom of the


### PR DESCRIPTION
Reverts dxw/rails-template#295

One of our dependencies we pull in via Sprockets must use CoffeeScript, so we can't get away from it just yet.