### PR TITLE
Improve the Docker process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -110,7 +110,6 @@ ARG TIME_OF_BUILD
 ENV CURRENT_GIT_SHA ${CURRENT_GIT_SHA}
 ENV TIME_OF_BUILD ${TIME_OF_BUILD}
 
-# db setup
 COPY ./docker-entrypoint.sh /
 RUN chmod +x /docker-entrypoint.sh
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,13 @@ LABEL org.opencontainers.image.authors="contact@dxw.com"
 
 RUN curl -L https://deb.nodesource.com/setup_16.x | bash -
 RUN curl https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
-RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
+RUN \
+  echo "deb https://dl.yarnpkg.com/debian/ stable main" | \
+  tee /etc/apt/sources.list.d/yarn.list
 
-RUN apt-get update && apt-get install -y --fix-missing --no-install-recommends \
+RUN \
+  apt-get update && \
+  apt-get install -y --fix-missing --no-install-recommends \
   build-essential \
   libpq-dev
 
@@ -80,8 +84,10 @@ RUN mkdir -p tmp/pids
 # This must be ordered before rake assets:precompile
 RUN cp -R $DEPS_HOME/node_modules $APP_HOME/node_modules
 
-RUN if [ "$RAILS_ENV" = "production" ]; then \
-  RAILS_ENV="production" SECRET_KEY_BASE="secret" bundle exec rake assets:precompile; \
+RUN \
+  if [ "$RAILS_ENV" = "production" ]; then \
+  SECRET_KEY_BASE="secret" \
+  bundle exec rake assets:precompile; \
   fi
 
 # TODO:

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Base
 # ------------------------------------------------------------------------------
 FROM ruby:2.7.4 as base
-MAINTAINER dxw <rails@dxw.com>
+LABEL org.opencontainers.image.authors="contact@dxw.com"
 
 RUN curl -L https://deb.nodesource.com/setup_16.x | bash -
 RUN curl https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -

--- a/Dockerfile
+++ b/Dockerfile
@@ -80,13 +80,13 @@ RUN mkdir -p ${APP_HOME}/tmp
 
 COPY config.ru ${APP_HOME}/config.ru
 COPY Rakefile ${APP_HOME}/Rakefile
+COPY script ${APP_HOME}/script
 COPY public ${APP_HOME}/public
 COPY vendor ${APP_HOME}/vendor
 COPY bin ${APP_HOME}/bin
-COPY lib ${APP_HOME}/lib
 COPY config ${APP_HOME}/config
+COPY lib ${APP_HOME}/lib
 COPY db ${APP_HOME}/db
-COPY script ${APP_HOME}/script
 COPY app ${APP_HOME}/app
 # End
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,6 @@ FROM base AS dependencies
 
 RUN apt-get update && apt-get install -y yarn
 
-RUN mkdir -p ${DEPS_HOME}
 WORKDIR ${DEPS_HOME}
 
 # Install Javascript dependencies
@@ -55,7 +54,6 @@ RUN bundle install --retry=10 --jobs=4
 # ------------------------------------------------------------------------------
 FROM base AS web
 
-RUN mkdir -p ${APP_HOME}
 WORKDIR ${APP_HOME}
 
 # Copy dependencies (relying on dependencies using the same base image as this)

--- a/Dockerfile
+++ b/Dockerfile
@@ -102,13 +102,13 @@ RUN \
 # TODO:
 # In order to expose the current git sha & time of build in the /healthcheck
 # endpoint, pass these values into your deployment script, for example:
-# --build-arg current_sha="$GITHUB_SHA" \
-# --build-arg time_of_build="$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
-ARG current_sha
-ARG time_of_build
+# --build-arg CURRENT_GIT_SHA="$GITHUB_SHA" \
+# --build-arg TIME_OF_BUILD="$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
+ARG CURRENT_GIT_SHA
+ARG TIME_OF_BUILD
 
-ENV CURRENT_SHA=$current_sha
-ENV TIME_OF_BUILD=$time_of_build
+ENV CURRENT_GIT_SHA ${CURRENT_GIT_SHA}
+ENV TIME_OF_BUILD ${TIME_OF_BUILD}
 
 # db setup
 COPY ./docker-entrypoint.sh /

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,7 +4,7 @@ class ApplicationController < ActionController::Base
   def health_check
     render json: {
       rails: "OK",
-      git_sha: ENV.fetch("CURRENT_SHA", "UNKNOWN"),
+      git_sha: ENV.fetch("CURRENT_GIT_SHA", "UNKNOWN"),
       built_at: ENV.fetch("TIME_OF_BUILD", "UNKNOWN")
     }, status: :ok
   end

--- a/script/docker/bootstrap
+++ b/script/docker/bootstrap
@@ -7,8 +7,21 @@ set -e
 # Enable the running of this script from any subdirectory without moving to root
 cd "$(dirname "$0")/../.."
 
-echo "==> Building web Docker image..."
-docker-compose build web
+DOCKER_BUILD_ARGS=
+for arg in "$@"; do
+  case $arg in
+  --no-docker-cache)
+    DOCKER_BUILD_ARGS="--no-cache $DOCKER_BUILD_ARGS"
+    ;;
+  esac
+  shift
+done
 
-echo "==> Building test Docker image..."
-docker-compose -f docker-compose.test.yml build test
+for file_and_image in docker-compose.yml:web docker-compose.test.yml:test; do
+  file=${file_and_image%:*}
+  image=${file_and_image#*:}
+
+  echo "==> Building $file_and_image Docker image..."
+  # shellcheck disable=SC2086
+  docker-compose -f $file build $DOCKER_BUILD_ARGS $image
+done

--- a/script/docker/bootstrap
+++ b/script/docker/bootstrap
@@ -7,5 +7,8 @@ set -e
 # Enable the running of this script from any subdirectory without moving to root
 cd "$(dirname "$0")/../.."
 
-echo "==> Rebuilding Docker image to provision all dependencies..."
+echo "==> Building web Docker image..."
 docker-compose build web
+
+echo "==> Building test Docker image..."
+docker-compose -f docker-compose.test.yml build test

--- a/script/docker/setup
+++ b/script/docker/setup
@@ -9,6 +9,8 @@ set -e
 cd "$(dirname "$0")/../.."
 
 echo "==> Tearing down any previous application state..."
-docker-compose down --rmi local --volumes --remove-orphans
+for file in docker-compose.yml docker-compose.test.yml; do
+  docker-compose -f $file down --rmi local --volumes --remove-orphans
+done
 
 script/docker/bootstrap

--- a/script/docker/setup
+++ b/script/docker/setup
@@ -13,4 +13,4 @@ for file in docker-compose.yml docker-compose.test.yml; do
   docker-compose -f $file down --rmi local --volumes --remove-orphans
 done
 
-script/docker/bootstrap
+script/docker/bootstrap --no-docker-cache

--- a/script/docker/update
+++ b/script/docker/update
@@ -7,5 +7,5 @@ set -e
 # Enable the running of this script from any subdirectory without moving to root
 cd "$(dirname "$0")/../.."
 
-echo "==> Rebuilding Docker image in order to bundle new gems..."
-docker-compose build web
+echo "==> Bootstrapping..."
+script/docker/bootstrap

--- a/spec/requests/health_check_spec.rb
+++ b/spec/requests/health_check_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Health Check" do
   end
 
   it "includes the git_sha if it is present" do
-    ClimateControl.modify CURRENT_SHA: "123-abc-456-def" do
+    ClimateControl.modify CURRENT_GIT_SHA: "123-abc-456-def" do
       get "/health_check", headers: {"CONTENT_TYPE" => "application/json", "ACCEPT" => "application/json"}
       expect(response).to have_http_status(:ok)
       expect(JSON.parse(response.body)).to include("git_sha" => "123-abc-456-def")
@@ -22,7 +22,7 @@ RSpec.describe "Health Check" do
   end
 
   it "returns UNKNOWN if the git_sha and / or built_at are unset" do
-    ClimateControl.modify TIME_OF_BUILD: nil, CURRENT_SHA: nil do
+    ClimateControl.modify CURRENT_GIT_SHA: nil, TIME_OF_BUILD: nil do
       get "/health_check", headers: {"CONTENT_TYPE" => "application/json", "ACCEPT" => "application/json"}
       expect(response).to have_http_status(:ok)
       expect(JSON.parse(response.body)).to include("built_at" => "UNKNOWN")


### PR DESCRIPTION
The core changes in this PR are splitting the Docker image into sub-images to reduce their overall size (and encourage the main image to be only what's needed to run the thing) and make the scripts also build and clean the test image, to reduce the startup time and generally make working with tests easier.

Please see the commit messages for details.