### PR TITLE
Use correct docker container name for script/docker/server

### DIFF
--- a/script/docker/server
+++ b/script/docker/server
@@ -13,4 +13,4 @@ cd "$(dirname "$0")/../.."
 docker-compose up --detach
 
 # TODO: Repace 'rails-template' with application name
-docker attach rails-template_web_1
+docker attach rails-template-web-1


### PR DESCRIPTION
Noticed on the citizens-advice/corporate-api project that the name of the container was `corporate-api-web-1`, not `corporate-api_web_1`. 