### PR TITLE
Fix: Production docker image built without test gems

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,9 +19,8 @@ RUN \
 ENV APP_HOME /srv/app
 ENV DEPS_HOME /deps
 
-ARG RAILS_ENV
-ENV RAILS_ENV ${RAILS_ENV:-production}
-ENV NODE_ENV ${RAILS_ENV:-production}
+ENV RAILS_ENV production
+ENV NODE_ENV production
 
 # ------------------------------------------------------------------------------
 # Dependencies
@@ -42,7 +41,7 @@ RUN gem update --system 3.3.5
 RUN gem install bundler -v 2.3.5
 RUN bundle config set frozen "true"
 RUN bundle config set no-cache "true"
-RUN bundle config set with "${BUNDLE_GEM_GROUPS}"
+RUN bundle config set without development test
 RUN bundle install --retry=10 --jobs=4
 # End
 

--- a/Rakefile
+++ b/Rakefile
@@ -7,5 +7,7 @@ require_relative "config/application"
 
 Rails.application.load_tasks
 
-desc "Run all the tests"
-task default: %i[spec standard]
+if Rails.env.development? || Rails.env.test?
+  desc "Run all the tests"
+  task default: %i[spec standard]
+end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -27,7 +27,7 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :uglifier
+  config.assets.js_compressor = Uglifier.new(harmony: true)
   # Set a css_compressor so sassc-rails does not overwrite the compressor when running the tests
   config.assets.css_compressor = nil
 

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -4,8 +4,6 @@ services:
     build:
       context: .
       target: test
-      args:
-        RAILS_ENV: "test"
       cache_from:
         - app_test:latest
     image: app_test

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -4,8 +4,6 @@ services:
     build:
       context: .
       target: test
-      args:
-        RAILS_ENV: "test"
     command: bundle exec rake
     ports:
       - "3000:3000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,9 +3,7 @@ services:
   web:
     build:
       context: .
-      target: web
-      args:
-        RAILS_ENV: "development"
+      target: development
     command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'"
     ports:
       - "3000:3000"


### PR DESCRIPTION
Backport of https://github.com/citizensadvice/corporate-api/pull/55

The CA Corporate API is headless, so it doesn't use node, which means it's likely that this doesn't yet correctly handle node modules.

## Changes in this PR

Before this change our Dockerfile wasn't correctly creating Docker images. It was bundling gems from the `test` group despite expecting `RAILS_ENV` to be set as `production` by default. We don't want to be deploying live artefacts that have test dependencies and tooling installed. They are bigger and increase the surface area for complexity and attacks.

The meat of this change is centered around the Dockerfile. Instead of using `RAILS_ENV` to try and let the user convey what gems they expected, we switch to creating more explicit docker build stages and select them with the `target` field instead.

## Testing

1. `DOCKER=1 script/test` should still run all the tests (and have the test gems to do so)
2. `DOCKER=1 script/server` should still start up a local development server and be accesible at localhost:3000

If you want to test this in production too you can temporarily copy this into your app directory, into a file called `docker-compose.production.yml`. Once there you can run `docker-compose -f docker-compose.production.yml up` to check it boots in the right environment and watch that the right gems were installed: 

```
version: "3.8"
services:
  web:
    build:
      context: .
      target: production
    command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'"
    ports:
      - "3000:3000"
    depends_on:
      - db
    env_file:
       - .env.development.local
    environment:
      # DONE: Update rails-template with application name
      DATABASE_URL: postgres://postgres:password@db:5432/corporate-api-production
      AUTOMATICALLY_FIX_LINTING: "true"
    volumes:
      - .:/srv/app
    tty: true
    stdin_open: true
    networks:
      - prod

  db:
    image: postgres
    volumes:
      - db-data:/var/lib/postgresql/data
    environment:
      POSTGRES_PASSWORD: password
      POSTGRES_HOST_AUTH_METHOD: trust
    networks:
      - prod

networks:
  prod:

volumes:
  db-data:
```