### PR TITLE
Add -x to shellcheck to check sourced files

### DIFF
--- a/script/all/test
+++ b/script/all/test
@@ -22,7 +22,7 @@ else
   echo "==> Running ShellCheck..."
   for file in $(git ls-files script/*)
   do
-    shellcheck "$file"
+    shellcheck -x "$file"
   done
 
   if [ -n "$AUTOMATICALLY_FIX_LINTING" ]; then


### PR DESCRIPTION
The tests fail in local docker for the bumped rails version without this, but not on CI...

```
==> Running ShellCheck...

In script/bootstrap line 11:
. script/all/process-script-args
  ^----------------------------^ SC1091: Not following: script/all/process-script-args was not specified as input (see shellcheck -x).

For more information:
  https://www.shellcheck.net/wiki/SC1091 -- Not following: script/all/process...
ERROR: 1
```