### PR TITLE
Prevent setting this app from changing global bundle

### DIFF
--- a/script/no-docker/bootstrap
+++ b/script/no-docker/bootstrap
@@ -52,7 +52,7 @@ fi
 
 if ! bundle check >/dev/null 2>&1; then
   echo "==> Installing Ruby dependencies..."
-  bundle config set path vendor/bundle
+  bundle config set --local path vendor/bundle
   bundle install
 fi
 


### PR DESCRIPTION
When we bootstrap we get this message:

```
==> Bootstrapping...
==> Installing Ruby dependencies...
Your application has set path to "vendor/bundle". This will override the global value you are currently setting
```

This points at the change to your systems `bundle config`. If you check it it will have set the global path to vendor/bundle.

This will cause problems as you switch between different repositories and it'll stop using system gems without you knowing. This can cause instability as we saw on CITA with Webpacker failing spectacularly.

This change sets bundlers path with in the local context only. Meaning it will only change how bundle behaves within this directory.

<!-- Do you need to update the changelog? -->
