### PR TITLE
Fix: Update rebase action to 1.7

### DIFF
--- a/.github/workflows/automatic-rebase.yml
+++ b/.github/workflows/automatic-rebase.yml
@@ -57,7 +57,7 @@ jobs:
           fetch-depth: 0
 
       - name: Rebase on top of the default branch
-        uses: cirrus-actions/rebase@1.4
+        uses: cirrus-actions/rebase@1.7
         env:
           GITHUB_TOKEN: ${{ env.AUTO_REBASE_PERSONAL_ACCESS_TOKEN }}
 


### PR DESCRIPTION
## Changes in this PR

`cirrus-actions/rebase` is currently failing with the following:

```
fatal: unsafe repository ('/github/workspace' is owned by someone else)
To add an exception for this directory, call:
  git config --global --add safe.directory /github/workspace
```

This is a known issue, fixed in [v1.6](https://github.com/cirrus-actions/rebase/releases/tag/1.6).

## Next steps

- [ ] Run any necessary
      [accessibility testing](https://playbook.dxw.com/guides/web-accessibility.html)
      on this feature.
