### PR TITLE
Do not auto fix linter errors in CI

### DIFF
--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -21,7 +21,6 @@ services:
       DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL: "true"
       SECRET_KEY_BASE: secret
       CI: "true"
-      AUTOMATICALLY_FIX_LINTING: "false"
     networks:
       - test-ci
 

--- a/script/all/test
+++ b/script/all/test
@@ -2,6 +2,9 @@
 
 # Run the test suite for the application. Optionally pass in a path to an
 # individual test file to run a single test.
+#
+# To automtically fix linter errors, set AUTOMATICALLY_FIX_LINTING=true, to not
+# automatically fix linter errors, do not set AUTOMATICALLY_FIX_LINTING.
 
 set -e
 


### PR DESCRIPTION
The `script/all/test` script checks for the presence of
AUTOMATICALLY_FIX_LINTING not it's value, so supplying the variable in
`docker-comopse.ci.yml` as false effectively gives you the behaviour of
setting it to true - which is unexpected and confusing.
