### PR TITLE
Fix stylelint config CI error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -134,6 +134,7 @@ COPY .eslintignore ${APP_HOME}/.eslintignore
 COPY .eslintrc.json ${APP_HOME}/.eslintrc.json
 COPY .prettierignore ${APP_HOME}/.prettierignore
 COPY .prettierrc ${APP_HOME}/.prettierrc
+COPY .stylelintrc.json ${APP_HOME}/.stylelintrc.json
 
 COPY .rspec ${APP_HOME}/.rspec
 COPY spec ${APP_HOME}/spec


### PR DESCRIPTION
## Changes in this PR

The CI was complaining about having no configuration for `/srv/app/app/assets/stylesheets/1st_load_framework.css.scss`

I tested moving the config to `package.json`, which fixed the errors. In the process, I noticed lines such as the one below while observing the end of the CI build step. I noticed that `.stylelintrc.json` was not being copied, so this rectifies that, fixing the issue without needing to put stylelint config in `package.json`

`Step 63/65 : COPY .prettierrc ${APP_HOME}/.prettierrc`

Note the CI tests will still fail, but they will fail in an expected way - highlighting linting issues, rather than config issues

## Next steps

- [ ] Run any necessary
      [accessibility testing](https://playbook.dxw.com/guides/web-accessibility.html)
      on this feature.
