### PR TITLE
Fix or ignore stylelint errors

### DIFF
--- a/app/assets/stylesheets/1st_load_framework.css.scss
+++ b/app/assets/stylesheets/1st_load_framework.css.scss
@@ -1,3 +1,4 @@
+/* stylelint-disable scss/at-extend-no-missing-placeholder */
 // import the CSS framework
 // Do not use *= require in Sass or your other stylesheets will not be able to access the Bootstrap mixins and variables.
 @import "bootstrap";
@@ -5,8 +6,10 @@
 // make all images responsive by default
 img {
   @extend .img-fluid;
+
   margin: 0 auto;
 }
+
 // override for the 'Home' navigation link
 .navbar-brand {
   font-size: inherit;
@@ -17,15 +20,20 @@ img {
 // to make views framework-neutral
 .column {
   @extend .col-md-6;
+
   text-align: center;
 }
+
 .form {
   @extend .col-md-6;
 }
+
 .form-centered {
   @extend .col-md-6;
+
   text-align: center;
 }
+
 .submit {
   @extend .btn;
   @extend .btn-primary;
@@ -36,10 +44,13 @@ img {
 // to make views framework-neutral
 main {
   @extend .container;
+
   margin-top: 30px; // accommodate the navbar
 }
 
 section {
   @extend .row;
+
   margin-top: 20px;
 }
+/* stylelint-enable scss/at-extend-no-missing-placeholder */


### PR DESCRIPTION
This fixes errors reported by stylelint ready for the merge of #469. One issue it raised was the use of `@extend` with classes rather than placeholder selectors. Since we're extending Bootstrap classes here, we don't have the option to use placeholder selectors, so I've disabled this rule in the offending stylesheet

@see https://github.com/stylelint-scss/stylelint-scss/blob/master/src/rules/at-extend-no-missing-placeholder/README.md
