### PR TITLE
Update spring gem for Rails 7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,6 @@ group :development do
   gem "rails_layout"
   gem "spring"
   gem "spring-commands-rspec"
-  gem "spring-watcher-listen", "~> 2.0.0"
   gem "web-console", ">= 3.3.0"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -323,12 +323,9 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
-    spring (2.1.1)
+    spring (4.1.1)
     spring-commands-rspec (1.0.4)
       spring (>= 0.9.1)
-    spring-watcher-listen (2.0.1)
-      listen (>= 2.7, < 4.0)
-      spring (>= 1.2, < 3.0)
     sprockets (4.2.0)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
@@ -404,7 +401,6 @@ DEPENDENCIES
   simplecov
   spring
   spring-commands-rspec
-  spring-watcher-listen (~> 2.0.0)
   standard
   turbolinks (~> 5)
   tzinfo-data


### PR DESCRIPTION
We needed to go from v2 to at least v3.0.0 as per:

https://edgeguides.rubyonrails.org/upgrading_ruby_on_rails.html#upgrading-from-rails-6-1-to-rails-7-0-spring

Removing `spring-watcher-listen` was the easy way to do this. If that's an important part of people's workflow then they can figure out how to make it work. (I note from https://github.com/rails/spring-watcher-listen that there may be issues running spring-watcher-listen with ARM Macs.)

