### PR TITLE
Fix setup script messaging

### DIFF
--- a/script/no-docker/setup
+++ b/script/no-docker/setup
@@ -22,7 +22,7 @@ bundle exec rails db:drop
 DB_DROP_RESULT=$?
 set -e
 
-if [ -z "$CI" ] && [ -n "$DB_DROP_RESULT" ]; then
+if [ -z "$CI" ] && [ "$DB_DROP_RESULT" != 0 ]; then
   printf "\\nDatabase drop failed. Continue anyway? [y/N] "
   read -r
 
@@ -44,7 +44,7 @@ RAILS_ENV="test" bundle exec rails db:drop
 DB_DROP_RESULT=$?
 set -e
 
-if [ -z "$CI" ] && [ -n "$DB_DROP_RESULT" ]; then
+if [ -z "$CI" ] && [ "$DB_DROP_RESULT" != 0 ]; then
   printf "\\nDatabase drop failed. Continue anyway? [y/N] "
   read -r
 


### PR DESCRIPTION
This was saying a database drop failed even when it didn't. This updates some conditional logic so that it reports correctly
