### PR TITLE
Update for new docker compose

### DIFF
--- a/doc/architecture/decisions/0005-use-dotenv-for-managing-environment-variables.md
+++ b/doc/architecture/decisions/0005-use-dotenv-for-managing-environment-variables.md
@@ -41,7 +41,7 @@ Use DotEnv to load our environment variables.
 
 Should Docker and Docker Compose be added to the project the environment
 variables will need to be loaded with
-`docker-compose up --env-file=.env.development` rather than `docker-compose.env`
+`docker compose up --env-file=.env.development` rather than `docker-compose.env`
 which is a pattern we have used. Having 2 files for managing environment
 variables such as `.env*` and `docker-compose.env*` is undesirable due to the
 overhead in keeping these in sync.

--- a/script/ci/cibuild
+++ b/script/ci/cibuild
@@ -5,4 +5,4 @@
 
 set -e
 
-docker-compose -f docker-compose.ci.yml -p app build
+docker compose -f docker-compose.ci.yml -p app build

--- a/script/ci/test
+++ b/script/ci/test
@@ -6,7 +6,7 @@
 
 set -e
 
-docker-compose -f docker-compose.ci.yml \
+docker compose -f docker-compose.ci.yml \
                -p app \
                run --rm test \
                script/all/test "$@"

--- a/script/docker/console
+++ b/script/docker/console
@@ -8,4 +8,4 @@ set -e
 # Enable the running of this script from any subdirectory without moving to root
 cd "$(dirname "$0")/../.."
 
-docker-compose run --rm web bundle exec rails console
+docker compose run --rm web bundle exec rails console

--- a/script/docker/server
+++ b/script/docker/server
@@ -10,7 +10,7 @@ cd "$(dirname "$0")/../.."
 
 # INFO: To enable debug prompts (with pry or byebug) we first start the process
 # in the background and then use attach to create an interactive prompt.
-docker-compose up --detach
+docker compose up --detach
 
 # TODO: Repace 'rails-template' with application name
 docker attach rails-template_web_1

--- a/script/docker/setup
+++ b/script/docker/setup
@@ -10,7 +10,7 @@ cd "$(dirname "$0")/../.."
 
 echo "==> Tearing down any previous application state..."
 for file in docker-compose.yml docker-compose.test.yml; do
-  docker-compose -f $file down --rmi local --volumes --remove-orphans
+  docker compose -f $file down --rmi local --volumes --remove-orphans
 done
 
 script/docker/bootstrap --no-docker-cache

--- a/script/docker/test
+++ b/script/docker/test
@@ -7,6 +7,6 @@ set -e
 # Enable the running of this script from any subdirectory without moving to root
 cd "$(dirname "$0")/../.."
 
-docker-compose -f docker-compose.test.yml \
+docker compose -f docker-compose.test.yml \
                run --rm test \
                script/all/test "$@"


### PR DESCRIPTION
Docker compose is no longer available as `docker-compose`.

Update the project to account for this.

https://docs.docker.com/compose/migrate/

