### PR TITLE
Move from dotenv-rails to dotenv

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,7 @@ group :development, :test do
   gem "brakeman"
   gem "bullet"
   gem "byebug", platforms: %i[mri mingw x64_mingw]
-  gem "dotenv-rails"
+  gem "dotenv"
   gem "factory_bot_rails"
   gem "faker"
   gem "rspec-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,9 +128,6 @@ GEM
     diff-lcs (1.5.1)
     docile (1.4.0)
     dotenv (3.1.4)
-    dotenv-rails (3.1.4)
-      dotenv (= 3.1.4)
-      railties (>= 6.1)
     drb (2.2.1)
     erubi (1.13.0)
     execjs (2.9.1)
@@ -404,7 +401,7 @@ DEPENDENCIES
   coffee-rails (~> 5.0)
   database_cleaner
   database_cleaner-active_record
-  dotenv-rails
+  dotenv
   factory_bot_rails
   faker
   high_voltage


### PR DESCRIPTION
"The `dotenv-rails` gem is now superfluous. It's not technically deprecated yet and will continue to work, but the `dotenv` gem does the same thing."

https://github.com/bkeepers/dotenv/blob/main/Changelog.md#300