### PR TITLE
Keep Dockerfile Node version up to date

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@
 FROM ruby:3.3.5 as base
 LABEL org.opencontainers.image.authors="contact@dxw.com"
 
-RUN curl -L https://deb.nodesource.com/setup_20.x | bash -
+COPY .node-version .node-version
+RUN curl -L "https://deb.nodesource.com/setup_$(cat .node-version | cut -c1-2).x" | bash -
 RUN curl https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 RUN \
   echo "deb https://dl.yarnpkg.com/debian/ stable main" | \


### PR DESCRIPTION
This will ensure that the major version of Node used for setup by Docker will match the version in the .node-version file. We did this in Apply for Landing after encountering an engine mismatch error on a Renovate PR bumping the major version

https://github.com/dxw/dfsseta-apply-for-landing-ruby/commit/acc23196430c8af7585fc993ce0b2eb91a11a888