### PR TITLE
Compile assets in Docker-less setup and update scripts

### DIFF
--- a/script/no-docker/setup
+++ b/script/no-docker/setup
@@ -16,6 +16,10 @@ fi
 echo "==> Bootstrapping..."
 script/no-docker/bootstrap
 
+echo "==> Compiling assets..."
+yarn build
+yarn build:css
+
 echo "==> Dropping database..."
 set +e
 bundle exec rails db:drop

--- a/script/no-docker/update
+++ b/script/no-docker/update
@@ -7,6 +7,10 @@ set -e
 echo "==> Bootstrapping..."
 script/no-docker/bootstrap
 
+echo "==> Compiling assets..."
+yarn build
+yarn build:css
+
 echo "==> Running database migrations..."
 bundle exec rails db:migrate
 


### PR DESCRIPTION
This was added in Apply for Landing last year and seems like a useful default for smoother onboarding

"If you don't already have the compiled assets in `app/assets/builds`, `script/test` will fail and pages will fail to load using `script/server`. This adds the build step to the Docker-less `setup` and `update` scripts, the latter of which is used in the `test` and `server` scripts, to ensure the assets are compiled before they're needed"

https://github.com/dxw/dfsseta-apply-for-landing-ruby/commit/f56c707587913c4ce51c3dc7ea93ed1692a09711#diff-803dcb1d5b5cec24bdc12fdfd664507c8ef37a24deab57275c915b0a7af48a67R19